### PR TITLE
Send the serialized rows as `RawValue`

### DIFF
--- a/src-tauri/src/postgres/commands.rs
+++ b/src-tauri/src/postgres/commands.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::Context;
 use futures_util::{pin_mut, TryStreamExt};
+use serde_json::value::RawValue;
 use tauri::ipc::Channel;
 use tokio_postgres::types::ToSql;
 use uuid::Uuid;
@@ -138,7 +139,7 @@ pub async fn execute_query_stream(
 
             let mut columns_sent = false;
             let mut batch_size = 50;
-            let max_batch_size = 150;
+            let max_batch_size = 500;
             let mut total_rows = 0;
 
             let mut writer = RowWriter::new();
@@ -161,6 +162,9 @@ pub async fn execute_query_stream(
                         writer.add_row(&row)?;
 
                         total_rows += 1;
+
+                        // let s = serde_json::from_str::<&RawValue>("hey").unwrap();
+                        // TODO: maybe writer.finish returns RawValue directly?
 
                         if writer.len() >= batch_size {
                             channel

--- a/src-tauri/src/postgres/row_writer.rs
+++ b/src-tauri/src/postgres/row_writer.rs
@@ -1,4 +1,5 @@
 use rust_decimal::Decimal;
+use serde_json::value::RawValue;
 use std::fmt::Write;
 use tokio_postgres::{types::Type, Row};
 
@@ -58,10 +59,11 @@ impl RowWriter {
         self.row_count == 0
     }
 
-    pub fn finish(&mut self) -> String {
+    pub fn finish(&mut self) -> Box<RawValue> {
         self.json.push(']');
 
-        std::mem::replace(&mut self.json, String::new())
+        let json = std::mem::replace(&mut self.json, String::new());
+        RawValue::from_string(json).unwrap()
     }
 
     pub fn clear(&mut self) {
@@ -359,7 +361,7 @@ mod tests {
         let mut writer = RowWriter::new();
         writer.add_row(&row).unwrap();
         let result = writer.finish();
-        let result: Value = serde_json::from_str(&result).unwrap();
+        let result: Value = serde_json::from_str(result.get()).unwrap();
         assert_eq!(
             result,
             serde_json::json!([

--- a/src-tauri/src/postgres/types.rs
+++ b/src-tauri/src/postgres/types.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
 use tokio_postgres::Client;
 use uuid::Uuid;
 
@@ -45,7 +46,7 @@ pub struct DatabaseSchema {
     pub unique_columns: Vec<String>,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Serialize)]
 #[serde(
     rename_all = "camelCase",
     rename_all_fields = "camelCase",
@@ -60,7 +61,7 @@ pub enum QueryStreamEvent<'a> {
     },
     Batch {
         // serialized JSON through [`RowBatch`]
-        rows: String,
+        rows: Box<RawValue>,
     },
     /// all rows were sent
     Finish {},

--- a/src/lib/commands.svelte.ts
+++ b/src/lib/commands.svelte.ts
@@ -36,8 +36,7 @@ export type QueryStreamEvent =
 	| {
 			event: 'batch';
 			data: {
-				// JSON serialized rows
-				rows: string;
+				rows: any[][];
 			};
 	  }
 	| {

--- a/src/lib/components/StreamingQueryResults.svelte
+++ b/src/lib/components/StreamingQueryResults.svelte
@@ -41,17 +41,24 @@
 
 			case 'batch':
 				console.log('Got batch data');
-				const rawRows = event.data.rows.trim();
-				const rows = rawRows === '' ? [] : JSON.parse(rawRows);
+				const rows = event.data.rows || [];
 
 				console.log(`Adding ${rows.length} rows to stream`);
-				const newRows = rows.map((row: any[]) => {
+
+				const columnCount = queryColumns.length;
+				const rowCount = rows.length;
+				const newRows = new Array(rowCount);
+
+				for (let i = 0; i < rowCount; i++) {
+					const row = rows[i];
 					const rowObj: Record<string, any> = {};
-					queryColumns.forEach((col, i) => {
-						rowObj[col] = row[i];
-					});
-					return rowObj;
-				});
+
+					for (let j = 0; j < columnCount; j++) {
+						rowObj[queryColumns[j]] = row[j];
+					}
+
+					newRows[i] = rowObj;
+				}
 
 				queryRows = queryRows.concat(newRows);
 				queryRowCount += rows.length;


### PR DESCRIPTION
Try to reduce latency/memory usage further by sending the JSON generated by `RowWriter` as a `RawValue` directly. Activity Monitor shows ~50MB less RAM usage, but might not be reproducible every time.

This can be improved a bit further by going from `Box<RowWriter>` into just `&RowWriter`, and reusing the buffer in `RowWriter`. The usage of the `finish` method could become weird, though