### PR TITLE
Improve test connection status message readability

### DIFF
--- a/src/lib/components/ConnectionForm.svelte
+++ b/src/lib/components/ConnectionForm.svelte
@@ -158,14 +158,14 @@
 
 		{#if testResult === 'success'}
 			<div
-				class="bg-success-light/50 border-success/20 flex items-center gap-2 rounded-lg border px-3 py-1.5"
+				class="bg-success/35 border-success/40 flex items-center gap-2 rounded-lg border px-3 py-1.5"
 			>
 				<CheckCircle class="text-success h-4 w-4" />
 				<span class="text-success-foreground/80 text-sm font-medium">Connection successful!</span>
 			</div>
 		{:else if testResult === 'error'}
 			<div
-				class="bg-error-light/50 border-error/20 flex items-center gap-2 rounded-lg border px-3 py-1.5"
+				class="bg-error/35 border-error/40 text-error-foreground flex items-center gap-2 rounded-lg border px-3 py-1.5"
 			>
 				<AlertCircle class="text-error h-4 w-4" />
 				<span class="text-error-foreground/80 text-sm font-medium">Connection failed</span>


### PR DESCRIPTION
Connection success and failure messages used very light backgrounds (-light/50) and semi-transparent text (/80). This caused poor contrast and made the text hard to read.

Before:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/e207c8d4-c094-47fb-8012-2c7844b40c9f" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/57d77f59-eb3c-4e60-a51e-962f51e27bcf" />

After:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/a2c03fd7-65f4-475c-b8df-ef93984beec1" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/688d977d-d07c-4af6-aeb7-d69dac2e7205" />