### PR TITLE
Align dark titlebar background with sidebar

### DIFF
--- a/src-tauri/src/init.rs
+++ b/src-tauri/src/init.rs
@@ -33,15 +33,14 @@ pub fn build_window(app: &tauri::App) -> tauri::Result<()> {
 
     #[cfg(target_os = "macos")]
     {
-        use tauri::{utils::config::WindowEffectsConfig, window::Effect, LogicalPosition};
-
+       use tauri::{utils::config::WindowEffectsConfig, window::{Effect, Color}, LogicalPosition};
         window_builder = window_builder
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .effects(WindowEffectsConfig {
                 effects: vec![Effect::WindowBackground],
                 state: None,
                 radius: Some(12.0),
-                color: None,
+                color: Some(Color(2, 6, 16, 255)),
             })
             .traffic_light_position(tauri::Position::Logical(LogicalPosition::new(16.0, 23.0)))
             .hidden_title(true);

--- a/src/app.css
+++ b/src/app.css
@@ -322,6 +322,17 @@
 	.focus-ring {
 		@apply focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none;
 	}
+
+	/* Titlebar Surface */
+	.titlebar-surface {
+		background: var(--glass-bg);
+		border-color: var(--sidebar-border);
+	}
+
+	.dark .titlebar-surface {
+		background-color: rgb(2, 6, 11);
+		border-color: var(--sidebar-border);
+	}
 }
 
 @keyframes fadeIn {

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -42,8 +42,8 @@
 </script>
 
 <div
-	class="border-border/50 flex h-12 items-center border-b select-none"
-	style="background-color: rgb(241, 245, 249);"
+  class="titlebar-surface border-sidebar-border flex h-12 items-center border-b select-none"
+  data-tauri-drag-region
 >
 	{#if isMacOS}
 		<div class="flex flex-1 items-center justify-center gap-3 pr-4 pl-20" data-tauri-drag-region>


### PR DESCRIPTION
In dark theme, the titlebar background color was a totally different from the sidebar. This PR updates the titlebar to use the same background color as the sidebar in dark and light mode. 

Before:  
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/38ffdb19-101a-4414-9786-4e2fc6c6d35c" />

After:  
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/27b85da8-625f-4656-a16e-57830e113b2a" />
