### PR TITLE
Use the same icons on sidebar for connection form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,11 @@
 				"@codemirror/lint": "^6.8.5",
 				"@codemirror/search": "^6.5.11",
 				"@codemirror/state": "^6.5.2",
-				"@codemirror/theme-one-dark": "^6.1.3",
 				"@codemirror/view": "^6.38.1",
 				"@tailwindcss/vite": "^4.1.7",
 				"@tauri-apps/api": "^2.5.0",
 				"@types/node": "^22.15.19",
 				"clsx": "^2.1.1",
-				"codemirror": "^6.0.2",
 				"tailwind-merge": "^3.3.0",
 				"tailwindcss": "^4.1.7"
 			},
@@ -164,17 +162,6 @@
 			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
 			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
-			}
-		},
-		"node_modules/@codemirror/theme-one-dark": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
-			"integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
-			"dependencies": {
-				"@codemirror/language": "^6.0.0",
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0",
-				"@lezer/highlight": "^1.0.0"
 			}
 		},
 		"node_modules/@codemirror/view": {
@@ -2480,20 +2467,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/codemirror": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
-			"integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
-			"dependencies": {
-				"@codemirror/autocomplete": "^6.0.0",
-				"@codemirror/commands": "^6.0.0",
-				"@codemirror/language": "^6.0.0",
-				"@codemirror/lint": "^6.0.0",
-				"@codemirror/search": "^6.0.0",
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0"
 			}
 		},
 		"node_modules/color-convert": {

--- a/src/lib/components/ConnectionForm.svelte
+++ b/src/lib/components/ConnectionForm.svelte
@@ -1,16 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import {
-		Cable,
-		X,
-		CheckCircle,
-		AlertCircle,
-		Info,
-		Database,
-		Server,
-		FolderOpen
-	} from '@lucide/svelte';
+	import { Cable, X, CheckCircle, AlertCircle, Info, FolderOpen } from '@lucide/svelte';
 
 	import IconCibPostgresql from '~icons/cib/postgresql';
 	import IconSimpleIconsSqlite from '~icons/simple-icons/sqlite';

--- a/src/lib/components/ConnectionForm.svelte
+++ b/src/lib/components/ConnectionForm.svelte
@@ -11,6 +11,10 @@
 		Server,
 		FolderOpen
 	} from '@lucide/svelte';
+
+	import IconCibPostgresql from '~icons/cib/postgresql';
+	import IconSimpleIconsSqlite from '~icons/simple-icons/sqlite';
+
 	import { Commands, type DatabaseInfo, type ConnectionInfo } from '$lib/commands.svelte';
 	import { Tabs } from 'bits-ui';
 
@@ -162,14 +166,14 @@
 						value="postgres"
 						class="data-[state=active]:bg-foreground data-[state=active]:text-background data-[state=inactive]:hover:bg-muted/30 data-[state=inactive]:text-muted-foreground flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold transition-all duration-200 data-[state=active]:shadow-lg"
 					>
-						<Server class="h-4 w-4" />
+						<IconCibPostgresql class="h-4 w-4" />
 						PostgreSQL
 					</Tabs.Trigger>
 					<Tabs.Trigger
 						value="sqlite"
 						class="data-[state=active]:bg-foreground data-[state=active]:text-background data-[state=inactive]:hover:bg-muted/30 data-[state=inactive]:text-muted-foreground flex items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-semibold transition-all duration-200 data-[state=active]:shadow-lg"
 					>
-						<Database class="h-4 w-4" />
+						<IconSimpleIconsSqlite class="h-4 w-4" />
 						SQLite
 					</Tabs.Trigger>
 				</Tabs.List>


### PR DESCRIPTION
Closes #16

This fixes the inconsistent icons between Connection Form and Sidebar for database types.

Sidebar:
<img width="400" height="400" alt="Image" src="https://github.com/user-attachments/assets/559f460f-0832-47ce-b990-3e3003152c2f" />

Connection Form before:
<img width="400" height="400" alt="Image" src="https://github.com/user-attachments/assets/c97b4b1d-4bbc-4ce2-99a1-2d9b178adee1" />

Connection Form after:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/79b8a7d4-c57a-4ef0-8a9a-4a226da43a01" />