### PR TITLE
Calls `cargo test` in CI and fixes build cache issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
 
   rust:
     name: Rust - fmt, clippy & unit testing
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: 0 # Disable incremental compilation for faster from-scratch builds
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -56,6 +59,8 @@ jobs:
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check


### PR DESCRIPTION
Adds additional run command on `rust` job to run unit tests, for that I had to add a postgres action so the runner would be able to execute it. As the caching layer was broken, I also added a new solution for the build cache.