### PR TITLE
Fix traffic lights position

### DIFF
--- a/src-tauri/src/database/postgres/row_writer/interval.rs
+++ b/src-tauri/src/database/postgres/row_writer/interval.rs
@@ -104,5 +104,3 @@ impl fmt::Display for PgInterval {
         Ok(())
     }
 }
-
-// '1 microsecond'::interval AS microsecond_interval

--- a/src-tauri/src/init.rs
+++ b/src-tauri/src/init.rs
@@ -50,7 +50,7 @@ pub fn build_window(app: &tauri::App) -> tauri::Result<()> {
                 radius: Some(12.0),
                 color: None,
             })
-            .traffic_light_position(tauri::Position::Logical(LogicalPosition::new(16.0, 23.0)))
+            .traffic_light_position(tauri::Position::Logical(LogicalPosition::new(16.0, 18.5)))
             .hidden_title(true)
     };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ pub use error::{Error, Result};
 pub struct AppState {
     pub connections: DashMap<Uuid, DatabaseConnection>,
     pub schemas: DashMap<Uuid, Arc<DatabaseSchema>>,
+    /// SQLite database for application data
     pub storage: Storage,
     pub stmt_manager: StatementManager,
 }
@@ -34,8 +35,6 @@ impl AppState {
     pub fn new() -> Result<Self> {
         let data_dir = dirs::data_dir().expect("Failed to get data directory");
         let db_path = data_dir.join("pgpad").join("pgpad.db");
-
-        dbg!(&db_path);
 
         let storage = Storage::new(db_path)?;
 


### PR DESCRIPTION
## Before

<img width="138" height="77" alt="image" src="https://github.com/user-attachments/assets/9a572f01-02d5-48be-bf9d-724b969ed9ae" />


## Now

<img width="119" height="51" alt="image" src="https://github.com/user-attachments/assets/b8b0622c-8311-4322-a748-05dbad860d78" />

Curiously, it still looks a bit off-centered to me, even though the ruler says otherwise. In Tableplus it looks like there's a 12pt/13pt split. Huh. This will do for now 


Closes #37 