### PR TITLE
Set sqlite busy timeout

### DIFF
--- a/pgpad-core/src/database/services.rs
+++ b/pgpad-core/src/database/services.rs
@@ -167,7 +167,7 @@ pub async fn connect_to_database(
                 }
             }
         }
-        ConnectionConfig::SQLite { db_path } => match rusqlite::Connection::open(&db_path) {
+        ConnectionConfig::SQLite { db_path } => match rusqlite::Connection::open(db_path) {
             Ok(conn) => {
                 // Set busy timeout so concurrent writers wait instead of
                 // immediately returning SQLITE_BUSY.

--- a/pgpad-core/src/database/services.rs
+++ b/pgpad-core/src/database/services.rs
@@ -167,8 +167,18 @@ pub async fn connect_to_database(
                 }
             }
         }
-        ConnectionConfig::SQLite { db_path } => match rusqlite::Connection::open(db_path) {
+        ConnectionConfig::SQLite { db_path } => match rusqlite::Connection::open(&db_path) {
             Ok(conn) => {
+                // Set busy timeout so concurrent writers wait instead of
+                // immediately returning SQLITE_BUSY.
+                if let Err(e) = conn.execute_batch("PRAGMA busy_timeout = 5000;") {
+                    log::error!(
+                        "Failed to set busy_timeout on SQLite database {}: {}",
+                        db_path,
+                        e
+                    );
+                }
+
                 connection.runtime = ConnectionRuntime::Connected(RuntimeClient::SQLite {
                     connection: Arc::new(Mutex::new(conn)),
                 });


### PR DESCRIPTION
Set a 5-second busy_timeout on SQLite connections to handle cases where another process holds a write lock.

Previously, if another process was writing to the database while pgpad was running, queries would fail immediately with SQLITE_BUSY. This caused some slowness.

With the new change, sqlite will wait up to 5 seconds for the lock to be released.