### PR TITLE
stmt_manager updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,6 +2974,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tower",
  "uuid",
 ]
@@ -5044,6 +5045,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/pgpad-core/src/database/stmt_manager.rs
+++ b/pgpad-core/src/database/stmt_manager.rs
@@ -1,8 +1,14 @@
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex, MutexGuard,
+};
 
 use anyhow::Context;
 use serde_json::value::RawValue;
-use tokio::task::{self, JoinHandle};
+use tokio::{
+    sync::broadcast,
+    task::{self, JoinHandle},
+};
 
 use dashmap::DashMap;
 
@@ -10,7 +16,7 @@ use crate::{
     database::{
         parser::ParsedStatement,
         postgres, sqlite,
-        types::{channel, Page, QueryId, QuerySnapshot, QueryStatus, RuntimeClient},
+        types::{channel, Page, QueryEvent, QueryId, QuerySnapshot, QueryStatus, RuntimeClient},
         QueryExecEvent,
     },
     utils::Condvar,
@@ -86,7 +92,7 @@ impl ExecState {
         }
     }
 
-    fn push_page(&self, page: Page) {
+    fn push_page(&self, page: Page) -> (usize, usize) {
         {
             let mut inner = self.inner();
 
@@ -96,15 +102,22 @@ impl ExecState {
                         columns: None,
                         pages: vec![page],
                     };
+                    self.renderable.set();
+                    return (0, 1);
                 }
                 ExecOutput::ResultSet { pages, .. } => {
                     pages.push(page);
+                    let page_index = pages.len() - 1;
+                    let page_count = pages.len();
+                    self.renderable.set();
+                    return (page_index, page_count);
                 }
                 ExecOutput::Modification { .. } => {}
             }
         }
 
         self.renderable.set();
+        (0, 0)
     }
 
     fn finish(&self, affected_rows: usize, error: Option<String>) {
@@ -204,6 +217,8 @@ pub struct StatementManager {
     queries: DashMap<QueryId, Arc<ExecState>>,
     /// Handles for tasks spawned by the current batch of queries
     task_handles: Mutex<Vec<JoinHandle<()>>>,
+    query_events: broadcast::Sender<QueryEvent>,
+    next_query_id: AtomicUsize,
 }
 
 impl std::fmt::Debug for StatementManager {
@@ -218,7 +233,13 @@ impl StatementManager {
         Self {
             queries: DashMap::new(),
             task_handles: Mutex::new(Vec::new()),
+            query_events: broadcast::channel(1024).0,
+            next_query_id: AtomicUsize::new(0),
         }
+    }
+
+    pub fn subscribe_query_events(&self) -> broadcast::Receiver<QueryEvent> {
+        self.query_events.subscribe()
     }
 
     fn stop_workers(&self) {
@@ -239,13 +260,28 @@ impl StatementManager {
         };
 
         let statements = parse_statements(query)?;
-        let mut query_ids = Vec::with_capacity(statements.len());
-        let mut handles = self.task_handles.lock().unwrap();
 
-        for (idx, statement) in statements.into_iter().enumerate() {
-            let new_handles = self.create_worker(idx as QueryId, client.clone(), statement);
+        let pending_workers: Vec<_> = statements
+            .into_iter()
+            .map(|stmt| {
+                let query_id = self.next_query_id.fetch_add(1, Ordering::Relaxed);
+                (query_id, stmt)
+            })
+            .collect();
+
+        let query_ids = pending_workers
+            .iter()
+            .map(|(query_id, _)| *query_id)
+            .collect::<Vec<_>>();
+
+        let _ = self.query_events.send(QueryEvent::Submitted {
+            query_ids: query_ids.clone(),
+        });
+
+        let mut handles = self.task_handles.lock().unwrap();
+        for (query_id, statement) in pending_workers {
+            let new_handles = self.create_worker(query_id, client.clone(), statement);
             handles.extend(new_handles);
-            query_ids.push(idx);
         }
 
         Ok(query_ids)
@@ -293,6 +329,7 @@ impl StatementManager {
         let exec_storage = ExecState::new(stmt.returns_values);
         let exec_storage = Arc::new(exec_storage);
         self.queries.insert(id, exec_storage.clone());
+        let query_events = self.query_events.clone();
 
         let (sender, recv) = channel();
 
@@ -318,20 +355,37 @@ impl StatementManager {
             while let Some(event) = recv.recv().await {
                 match event {
                     QueryExecEvent::TypesResolved { columns } => {
+                        let event_columns = columns.clone();
                         exec_storage.set_columns(columns);
+                        let _ = query_events.send(QueryEvent::ColumnsReady {
+                            query_id: id,
+                            columns: event_columns,
+                        });
                     }
                     QueryExecEvent::Page {
                         page_amount: _,
                         page,
                     } => {
-                        exec_storage.push_page(page);
+                        let (page_index, page_count) = exec_storage.push_page(page);
+                        let _ = query_events.send(QueryEvent::PageReady {
+                            query_id: id,
+                            page_index,
+                            page_count,
+                        });
                     }
                     QueryExecEvent::Finished {
                         elapsed_ms: _,
                         affected_rows,
                         error,
                     } => {
+                        let event_error = error.clone();
                         exec_storage.finish(affected_rows, error);
+                        let _ = query_events.send(QueryEvent::Finished {
+                            query_id: id,
+                            status: exec_storage.get_query_status(),
+                            affected_rows: (!exec_storage.returns_values).then_some(affected_rows),
+                            error: event_error,
+                        });
 
                         // TODO(vini): fingerprint query here, and save it?
 

--- a/pgpad-core/src/database/stmt_manager.rs
+++ b/pgpad-core/src/database/stmt_manager.rs
@@ -1,7 +1,4 @@
-use std::sync::{
-    atomic::{AtomicU8, Ordering},
-    Arc, Mutex, RwLock,
-};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use anyhow::Context;
 use serde_json::value::RawValue;
@@ -22,19 +19,184 @@ use crate::{
 
 /// The storage/state for an individual statement being executed
 struct ExecState {
-    status: AtomicU8,
-    pages: RwLock<Vec<Page>>,
-    error: RwLock<Option<String>>,
-    columns: RwLock<Option<Box<RawValue>>>,
     /// True if this query is expected to return some amount of rows
     /// False if this is a query that will never return anything (e.g. an UPDATE without a RETURNING clause)
-    // TODO(vini): we could refactor this into an enum with a variant with `pages`, `columns`, and one with just `rows_affected`
     returns_values: bool,
-    rows_affected: RwLock<Option<usize>>,
+    inner: Mutex<ExecInner>,
 
     /// If set, the UI can now render the results of this query,
     /// even if it's still on-going (e.g. we already have enough data to render the first page)
     renderable: Condvar,
+}
+
+struct ExecInner {
+    status: QueryStatus,
+    output: ExecOutput,
+    error: Option<String>,
+}
+
+enum ExecOutput {
+    Pending,
+    ResultSet {
+        columns: Option<Box<RawValue>>,
+        pages: Vec<Page>,
+    },
+    Modification {
+        affected_rows: Option<usize>,
+    },
+}
+
+impl ExecState {
+    fn new(returns_values: bool) -> Self {
+        Self {
+            returns_values,
+            inner: Mutex::new(ExecInner {
+                status: QueryStatus::Pending,
+                output: ExecOutput::Pending,
+                error: None,
+            }),
+            renderable: Condvar::new(),
+        }
+    }
+
+    fn inner(&self) -> MutexGuard<'_, ExecInner> {
+        self.inner.lock().expect("Mutex poisoned")
+    }
+
+    fn mark_running(&self) {
+        self.inner().status = QueryStatus::Running;
+    }
+
+    fn set_columns(&self, columns: Box<RawValue>) {
+        let mut inner = self.inner();
+
+        match &mut inner.output {
+            ExecOutput::Pending => {
+                inner.output = ExecOutput::ResultSet {
+                    columns: Some(columns),
+                    pages: vec![],
+                };
+            }
+            ExecOutput::ResultSet {
+                columns: existing, ..
+            } => {
+                *existing = Some(columns);
+            }
+            ExecOutput::Modification { .. } => {}
+        }
+    }
+
+    fn push_page(&self, page: Page) {
+        {
+            let mut inner = self.inner();
+
+            match &mut inner.output {
+                ExecOutput::Pending => {
+                    inner.output = ExecOutput::ResultSet {
+                        columns: None,
+                        pages: vec![page],
+                    };
+                }
+                ExecOutput::ResultSet { pages, .. } => {
+                    pages.push(page);
+                }
+                ExecOutput::Modification { .. } => {}
+            }
+        }
+
+        self.renderable.set();
+    }
+
+    fn finish(&self, affected_rows: usize, error: Option<String>) {
+        {
+            let mut inner = self.inner();
+
+            if let Some(message) = error {
+                inner.status = QueryStatus::Error;
+                inner.error = Some(message);
+            } else {
+                inner.status = QueryStatus::Completed;
+                inner.error = None;
+
+                if self.returns_values {
+                    if matches!(inner.output, ExecOutput::Pending) {
+                        inner.output = ExecOutput::ResultSet {
+                            columns: None,
+                            pages: vec![],
+                        };
+                    }
+                } else {
+                    inner.output = ExecOutput::Modification {
+                        affected_rows: Some(affected_rows),
+                    };
+                }
+            }
+        }
+
+        self.renderable.set();
+    }
+
+    fn snapshot(&self) -> QuerySnapshot {
+        let inner = self.inner();
+
+        match &inner.output {
+            ExecOutput::Pending => QuerySnapshot {
+                returns_values: self.returns_values,
+                status: inner.status,
+                first_page: None,
+                affected_rows: None,
+                error: inner.error.clone(),
+                columns: None,
+            },
+            ExecOutput::ResultSet { columns, pages } => QuerySnapshot {
+                returns_values: true,
+                status: inner.status,
+                first_page: pages.first().cloned(),
+                affected_rows: None,
+                error: inner.error.clone(),
+                columns: columns.clone(),
+            },
+            ExecOutput::Modification { affected_rows } => QuerySnapshot {
+                returns_values: false,
+                status: inner.status,
+                first_page: None,
+                affected_rows: *affected_rows,
+                error: inner.error.clone(),
+                columns: None,
+            },
+        }
+    }
+
+    fn get_columns(&self) -> Option<Box<RawValue>> {
+        let inner = self.inner();
+
+        match &inner.output {
+            ExecOutput::ResultSet { columns, .. } => columns.clone(),
+            ExecOutput::Pending | ExecOutput::Modification { .. } => None,
+        }
+    }
+
+    fn fetch_page(&self, page_idx: usize) -> Option<Page> {
+        let inner = self.inner();
+
+        match &inner.output {
+            ExecOutput::ResultSet { pages, .. } => pages.get(page_idx).cloned(),
+            ExecOutput::Pending | ExecOutput::Modification { .. } => None,
+        }
+    }
+
+    fn get_query_status(&self) -> QueryStatus {
+        self.inner().status
+    }
+
+    fn get_page_count(&self) -> usize {
+        let inner = self.inner();
+
+        match &inner.output {
+            ExecOutput::ResultSet { pages, .. } => pages.len(),
+            ExecOutput::Pending | ExecOutput::Modification { .. } => 0,
+        }
+    }
 }
 
 /// Executes and keeps track of the execution of queries.
@@ -99,51 +261,24 @@ impl StatementManager {
         // Wait for the data to load in
         exec_state.renderable.wait().await;
 
-        let returns_values = exec_state.returns_values;
-
-        let info = QuerySnapshot {
-            returns_values,
-            status: exec_state.status.load(Ordering::Relaxed).into(),
-            first_page: if returns_values {
-                let pages = exec_state.pages.read().expect("RwLock poisoned");
-                pages.first().cloned()
-            } else {
-                None
-            },
-            affected_rows: *exec_state.rows_affected.read().expect("RwLock poisoned"),
-            error: exec_state.error.read().expect("RwLock poisoned").clone(),
-            columns: exec_state.columns.read().expect("RwLock poisoned").clone(),
-        };
-
-        Ok(info)
+        Ok(exec_state.snapshot())
     }
 
     pub fn get_columns(&self, query_id: QueryId) -> Result<Option<Box<RawValue>>, Error> {
-        Ok(self
-            .get(query_id)?
-            .columns
-            .read()
-            .expect("RwLock poisoned")
-            .clone())
+        Ok(self.get(query_id)?.get_columns())
     }
 
     /// Fetches a page of results for a given query.
     pub fn fetch_page(&self, query_id: QueryId, page_idx: usize) -> Result<Option<Page>, Error> {
-        let exec_state = self.get(query_id)?;
-        let pages = exec_state.pages.read().expect("RwLock poisoned");
-        Ok(pages.get(page_idx).cloned())
+        Ok(self.get(query_id)?.fetch_page(page_idx))
     }
 
     pub fn get_query_status(&self, query_id: QueryId) -> Result<QueryStatus, Error> {
-        let exec_state = self.get(query_id)?;
-
-        Ok(exec_state.status.load(Ordering::Relaxed).into())
+        Ok(self.get(query_id)?.get_query_status())
     }
 
     pub fn get_page_count(&self, query_id: QueryId) -> Result<usize, Error> {
-        let exec_state = self.get(query_id)?;
-        let page_count = exec_state.pages.read().expect("RwLock poisoned").len();
-        Ok(page_count)
+        Ok(self.get(query_id)?.get_page_count())
     }
 }
 
@@ -155,16 +290,7 @@ impl StatementManager {
         client: RuntimeClient,
         stmt: ParsedStatement,
     ) -> [JoinHandle<()>; 2] {
-        let exec_storage = ExecState {
-            status: AtomicU8::new(QueryStatus::Pending as u8),
-            pages: RwLock::new(vec![]),
-            error: RwLock::new(None),
-            columns: RwLock::new(None),
-            returns_values: stmt.returns_values,
-            rows_affected: RwLock::new(None),
-            renderable: Condvar::new(),
-        };
-
+        let exec_storage = ExecState::new(stmt.returns_values);
         let exec_storage = Arc::new(exec_storage);
         self.queries.insert(id, exec_storage.clone());
 
@@ -187,41 +313,25 @@ impl StatementManager {
         let receiver_handle = task::spawn(async move {
             let mut recv = recv;
 
-            exec_storage
-                .status
-                .store(QueryStatus::Running as u8, Ordering::Relaxed);
+            exec_storage.mark_running();
 
             while let Some(event) = recv.recv().await {
                 match event {
                     QueryExecEvent::TypesResolved { columns } => {
-                        *exec_storage.columns.write().unwrap() = Some(columns);
+                        exec_storage.set_columns(columns);
                     }
                     QueryExecEvent::Page {
                         page_amount: _,
                         page,
                     } => {
-                        exec_storage.pages.write().unwrap().push(page);
-                        exec_storage.renderable.set();
+                        exec_storage.push_page(page);
                     }
                     QueryExecEvent::Finished {
                         elapsed_ms: _,
                         affected_rows,
                         error,
                     } => {
-                        if let Some(err) = error {
-                            *exec_storage.error.write().unwrap() = Some(err);
-                            exec_storage
-                                .status
-                                .store(QueryStatus::Error as u8, Ordering::Relaxed);
-                        } else {
-                            exec_storage
-                                .status
-                                .store(QueryStatus::Completed as u8, Ordering::Relaxed);
-
-                            *exec_storage.rows_affected.write().unwrap() = Some(affected_rows);
-                        }
-
-                        exec_storage.renderable.set();
+                        exec_storage.finish(affected_rows, error);
 
                         // TODO(vini): fingerprint query here, and save it?
 

--- a/pgpad-core/src/database/stmt_manager.rs
+++ b/pgpad-core/src/database/stmt_manager.rs
@@ -217,7 +217,7 @@ pub struct StatementManager {
     queries: DashMap<QueryId, Arc<ExecState>>,
     /// Handles for tasks spawned by the current batch of queries
     task_handles: Mutex<Vec<JoinHandle<()>>>,
-    query_events: broadcast::Sender<QueryEvent>,
+    query_events_sender: broadcast::Sender<QueryEvent>,
     next_query_id: AtomicUsize,
 }
 
@@ -233,13 +233,13 @@ impl StatementManager {
         Self {
             queries: DashMap::new(),
             task_handles: Mutex::new(Vec::new()),
-            query_events: broadcast::channel(1024).0,
+            query_events_sender: broadcast::channel(1024).0,
             next_query_id: AtomicUsize::new(0),
         }
     }
 
-    pub fn subscribe_query_events(&self) -> broadcast::Receiver<QueryEvent> {
-        self.query_events.subscribe()
+    pub fn query_events_receiver(&self) -> broadcast::Receiver<QueryEvent> {
+        self.query_events_sender.subscribe()
     }
 
     fn stop_workers(&self) {
@@ -274,7 +274,7 @@ impl StatementManager {
             .map(|(query_id, _)| *query_id)
             .collect::<Vec<_>>();
 
-        let _ = self.query_events.send(QueryEvent::Submitted {
+        let _ = self.query_events_sender.send(QueryEvent::Submitted {
             query_ids: query_ids.clone(),
         });
 
@@ -329,7 +329,7 @@ impl StatementManager {
         let exec_storage = ExecState::new(stmt.returns_values);
         let exec_storage = Arc::new(exec_storage);
         self.queries.insert(id, exec_storage.clone());
-        let query_events = self.query_events.clone();
+        let query_events_sender = self.query_events_sender.clone();
 
         let (sender, recv) = channel();
 
@@ -357,7 +357,7 @@ impl StatementManager {
                     QueryExecEvent::TypesResolved { columns } => {
                         let event_columns = columns.clone();
                         exec_storage.set_columns(columns);
-                        let _ = query_events.send(QueryEvent::ColumnsReady {
+                        let _ = query_events_sender.send(QueryEvent::ColumnsReady {
                             query_id: id,
                             columns: event_columns,
                         });
@@ -367,7 +367,7 @@ impl StatementManager {
                         page,
                     } => {
                         let (page_index, page_count) = exec_storage.push_page(page);
-                        let _ = query_events.send(QueryEvent::PageReady {
+                        let _ = query_events_sender.send(QueryEvent::PageReady {
                             query_id: id,
                             page_index,
                             page_count,
@@ -380,7 +380,7 @@ impl StatementManager {
                     } => {
                         let event_error = error.clone();
                         exec_storage.finish(affected_rows, error);
-                        let _ = query_events.send(QueryEvent::Finished {
+                        let _ = query_events_sender.send(QueryEvent::Finished {
                             query_id: id,
                             status: exec_storage.get_query_status(),
                             affected_rows: (!exec_storage.returns_values).then_some(affected_rows),
@@ -412,8 +412,9 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use serde_json::{json, value::RawValue};
+    use tokio::sync::broadcast;
 
-    use crate::database::types::RuntimeClient;
+    use crate::database::types::{QueryEvent, QueryStatus, RuntimeClient};
 
     use super::StatementManager;
 
@@ -433,9 +434,7 @@ mod tests {
     async fn run_query(query: &str) -> (Box<RawValue>, Box<RawValue>) {
         let stmt_manager = StatementManager::new();
 
-        let client = RuntimeClient::SQLite {
-            connection: Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap())),
-        };
+        let client = sqlite_client();
         let query_ids = stmt_manager.submit_query(client, query).unwrap();
         assert_eq!(query_ids, vec![0]);
 
@@ -474,5 +473,176 @@ mod tests {
             csv_export,
             "id,name,price\n1,\"apple\",0.99\n2,\"banana\",1.25\n3,\"cherry\",2.5\n"
         );
+    }
+
+    #[tokio::test]
+    async fn emits_events_for_select_query() {
+        let stmt_manager = StatementManager::new();
+        let mut events = stmt_manager.query_events_receiver();
+        let query_ids = stmt_manager
+            .submit_query(sqlite_client(), "SELECT 1 AS value")
+            .unwrap();
+
+        let events = collect_events_until_finished(&mut events, query_ids[0]).await;
+
+        assert!(matches!(
+            &events[0],
+            QueryEvent::Submitted { query_ids: ids } if ids == &query_ids
+        ));
+        assert!(matches!(
+            &events[1],
+            QueryEvent::ColumnsReady { query_id, columns }
+                if *query_id == query_ids[0]
+                    && serde_json::from_str::<serde_json::Value>(columns.get()).unwrap()
+                        == json!(["value"])
+        ));
+        assert!(matches!(
+            &events[2],
+            QueryEvent::PageReady {
+                query_id,
+                page_index,
+                page_count,
+            } if *query_id == query_ids[0] && *page_index == 0 && *page_count == 1
+        ));
+        assert!(matches!(
+            &events[3],
+            QueryEvent::Finished {
+                query_id,
+                status: QueryStatus::Completed,
+                affected_rows: None,
+                error: None,
+            } if *query_id == query_ids[0]
+        ));
+    }
+
+    #[tokio::test]
+    async fn submitted_event_precedes_multi_statement_result_events() {
+        let stmt_manager = StatementManager::new();
+        let mut events = stmt_manager.query_events_receiver();
+        let query_ids = stmt_manager
+            .submit_query(sqlite_client(), "SELECT 1; SELECT 2; SELECT 3; SELECT 4;")
+            .unwrap();
+
+        let first_event = events.recv().await.unwrap();
+
+        assert!(matches!(
+            first_event,
+            QueryEvent::Submitted { query_ids: ids } if ids == query_ids
+        ));
+    }
+
+    #[tokio::test]
+    async fn emits_events_for_modification_query() {
+        let stmt_manager = StatementManager::new();
+        let mut events = stmt_manager.query_events_receiver();
+        let query_ids = stmt_manager
+            .submit_query(sqlite_client(), "CREATE TABLE items (id INTEGER);")
+            .unwrap();
+
+        let events = collect_events_until_finished(&mut events, query_ids[0]).await;
+
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[0],
+            QueryEvent::Submitted { query_ids: ids } if ids == &query_ids
+        ));
+        assert!(matches!(
+            &events[1],
+            QueryEvent::Finished {
+                query_id,
+                status: QueryStatus::Completed,
+                affected_rows: Some(0),
+                error: None,
+            } if *query_id == query_ids[0]
+        ));
+    }
+
+    #[tokio::test]
+    async fn emits_error_event_for_invalid_query() {
+        let stmt_manager = StatementManager::new();
+        let mut events = stmt_manager.query_events_receiver();
+        let query_ids = stmt_manager
+            .submit_query(sqlite_client(), "SELECT * FROM missing_table")
+            .unwrap();
+
+        let events = collect_events_until_finished(&mut events, query_ids[0]).await;
+        let finished = events.last().unwrap();
+
+        assert!(matches!(
+            finished,
+            QueryEvent::Finished {
+                query_id,
+                status: QueryStatus::Error,
+                affected_rows: None,
+                error: Some(message),
+            } if *query_id == query_ids[0] && message.contains("missing_table")
+        ));
+    }
+
+    #[tokio::test]
+    async fn emits_page_ready_for_each_result_page() {
+        let stmt_manager = StatementManager::new();
+        let mut events = stmt_manager.query_events_receiver();
+        let query_ids = stmt_manager
+            .submit_query(
+                sqlite_client(),
+                "WITH RECURSIVE t(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM t WHERE x < 155) SELECT * FROM t;",
+            )
+            .unwrap();
+
+        let events = collect_events_until_finished(&mut events, query_ids[0]).await;
+        let page_events = events
+            .iter()
+            .filter_map(|event| match event {
+                QueryEvent::PageReady {
+                    query_id,
+                    page_index,
+                    page_count,
+                } => Some((*query_id, *page_index, *page_count)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            page_events,
+            vec![
+                (query_ids[0], 0, 1),
+                (query_ids[0], 1, 2),
+                (query_ids[0], 2, 3),
+                (query_ids[0], 3, 4),
+            ]
+        );
+    }
+
+    fn sqlite_client() -> RuntimeClient {
+        RuntimeClient::SQLite {
+            connection: Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap())),
+        }
+    }
+
+    async fn collect_events_until_finished(
+        events: &mut broadcast::Receiver<QueryEvent>,
+        query_id: usize,
+    ) -> Vec<QueryEvent> {
+        let mut collected = vec![];
+
+        loop {
+            let event = events.recv().await.unwrap();
+            let is_finished = matches!(
+                &event,
+                QueryEvent::Finished {
+                    query_id: finished_query_id,
+                    ..
+                } if *finished_query_id == query_id
+            );
+
+            collected.push(event);
+
+            if is_finished {
+                break;
+            }
+        }
+
+        collected
     }
 }

--- a/pgpad-core/src/database/types.rs
+++ b/pgpad-core/src/database/types.rs
@@ -34,7 +34,9 @@ pub struct QuerySnapshot {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum QueryEvent {
-    Submitted { query_ids: Vec<QueryId> },
+    Submitted {
+        query_ids: Vec<QueryId>,
+    },
     ColumnsReady {
         query_id: QueryId,
         columns: Box<RawValue>,

--- a/pgpad-core/src/database/types.rs
+++ b/pgpad-core/src/database/types.rs
@@ -31,6 +31,27 @@ pub struct QuerySnapshot {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum QueryEvent {
+    Submitted { query_ids: Vec<QueryId> },
+    ColumnsReady {
+        query_id: QueryId,
+        columns: Box<RawValue>,
+    },
+    PageReady {
+        query_id: QueryId,
+        page_index: usize,
+        page_count: usize,
+    },
+    Finished {
+        query_id: QueryId,
+        status: QueryStatus,
+        affected_rows: Option<usize>,
+        error: Option<String>,
+    },
+}
+
 pub enum Database {
     Postgres,
     Sqlite,

--- a/pgpad-web/Cargo.toml
+++ b/pgpad-web/Cargo.toml
@@ -16,6 +16,7 @@ rust-embed = "8.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["macros", "net", "rt-multi-thread"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 uuid = { version = "1.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/pgpad-web/src/lib.rs
+++ b/pgpad-web/src/lib.rs
@@ -1,11 +1,14 @@
-use std::{borrow::Cow, path::PathBuf, sync::Arc};
+use std::{borrow::Cow, convert::Infallible, path::PathBuf, sync::Arc};
 
 use axum::{
-    extract::{rejection::JsonRejection, FromRequest, Path, Request, State},
+    extract::{rejection::JsonRejection, FromRequest, Path, Query, Request, State},
     http::{header, HeaderMap, StatusCode, Uri},
     middleware::{self, Next},
-    response::{IntoResponse, Response},
-    routing::post,
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse, Response,
+    },
+    routing::{get, post},
     Json, Router,
 };
 use pgpad_core::{
@@ -23,6 +26,7 @@ use rfd::FileDialog;
 use rust_embed::Embed;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::value::RawValue;
+use tokio_stream::{wrappers::BroadcastStream, Stream, StreamExt};
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -137,6 +141,7 @@ pub fn router(state: WebState) -> Router {
 
     Router::new()
         .nest("/api", api)
+        .route("/api/events/query", get(query_events))
         .fallback(static_handler)
         .with_state(state)
 }
@@ -270,6 +275,43 @@ async fn require_auth_token(
     } else {
         Err(CommandHttpError::Unauthorized)
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct EventTokenArgs {
+    token: String,
+}
+
+async fn query_events(
+    State(state): State<WebState>,
+    Query(EventTokenArgs { token }): Query<EventTokenArgs>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, CommandHttpError> {
+    if token != state.auth_token() {
+        return Err(CommandHttpError::Unauthorized);
+    }
+
+    let query_events_receiver = state.app_state.stmt_manager.query_events_receiver();
+    let stream = BroadcastStream::new(query_events_receiver).filter_map(|event| {
+        let event = match event {
+            Ok(event) => event,
+            Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(skipped)) => {
+                log::warn!("Query event stream lagged and skipped {skipped} events");
+                return None;
+            }
+        };
+
+        let data = match serde_json::to_string(&event) {
+            Ok(data) => data,
+            Err(error) => {
+                log::error!("Failed to serialize query event: {error}");
+                return None;
+            }
+        };
+
+        Some(Ok(Event::default().event("query-event").data(data)))
+    });
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
 
 /// `Json<T>` from Axum, but that converts any errors into the Tauri-compatible error structure that the frontend expects

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,10 +58,10 @@ fn handle_query_events(handle: tauri::AppHandle) {
             return;
         };
 
-        let mut query_events = state.stmt_manager.subscribe_query_events();
+        let mut query_events_receiver = state.stmt_manager.query_events_receiver();
 
         loop {
-            match query_events.recv().await {
+            match query_events_receiver.recv().await {
                 Ok(event) => {
                     if let Err(e) = handle.emit_to(EventTarget::App, "query-event", event) {
                         log::error!("Error emitting query event: {e}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,31 @@ fn handle_dropped_connections(
     });
 }
 
+fn handle_query_events(handle: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let Some(state) = handle.try_state::<AppState>() else {
+            log::error!("No state manager found!");
+            return;
+        };
+
+        let mut query_events = state.stmt_manager.subscribe_query_events();
+
+        loop {
+            match query_events.recv().await {
+                Ok(event) => {
+                    if let Err(e) = handle.emit_to(EventTarget::App, "query-event", event) {
+                        log::error!("Error emitting query event: {e}");
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    log::warn!("Query event listener lagged and skipped {skipped} events");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+}
+
 #[allow(clippy::missing_panics_doc)]
 pub fn builder() -> tauri::Builder<tauri::Wry> {
     tauri::Builder::default()
@@ -77,6 +102,7 @@ pub fn builder() -> tauri::Builder<tauri::Wry> {
             let handle = app.handle();
             let (connection_monitor, dropped_connections) = ConnectionMonitor::new();
             handle_dropped_connections(handle.clone(), dropped_connections);
+            handle_query_events(handle.clone());
             handle.manage(connection_monitor);
             Ok(())
         })

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -55,9 +55,7 @@ class HttpBackend implements Backend {
 			return () => {};
 		}
 
-		const source = new EventSource(
-			`/api/events/query?token=${encodeURIComponent(token)}`
-		);
+		const source = new EventSource(`/api/events/query?token=${encodeURIComponent(token)}`);
 		const close = () => source.close();
 
 		source.addEventListener(event, (message) => {

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -58,6 +58,7 @@ class HttpBackend implements Backend {
 		const source = new EventSource(
 			`/api/events/query?token=${encodeURIComponent(token)}`
 		);
+		const close = () => source.close();
 
 		source.addEventListener(event, (message) => {
 			try {
@@ -67,11 +68,23 @@ class HttpBackend implements Backend {
 			}
 		});
 
-		source.onerror = (error) => {
-			console.error(`${event} stream error:`, error);
-		};
+		return await new Promise<Unlisten>((resolve, reject) => {
+			let opened = false;
 
-		return () => source.close();
+			source.onopen = () => {
+				opened = true;
+				resolve(close);
+			};
+
+			source.onerror = (error) => {
+				console.error(`${event} stream error:`, error);
+
+				if (!opened) {
+					close();
+					reject(new Error(`Failed to open ${event} stream`));
+				}
+			};
+		});
 	}
 
 	private commandHeaders(): HeadersInit {

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -45,9 +45,33 @@ class HttpBackend implements Backend {
 	}
 
 	async listen<T>(event: string, handler: (payload: T) => void): Promise<Unlisten> {
-		void event;
-		void handler;
-		return () => {};
+		if (event !== 'query-event') {
+			return () => {};
+		}
+
+		const token = getWebToken();
+		if (!token) {
+			console.warn(`Cannot listen for ${event}: missing pgpad-web token`);
+			return () => {};
+		}
+
+		const source = new EventSource(
+			`/api/events/query?token=${encodeURIComponent(token)}`
+		);
+
+		source.addEventListener(event, (message) => {
+			try {
+				handler(JSON.parse(message.data) as T);
+			} catch (error) {
+				console.error(`Failed to parse ${event} event:`, error);
+			}
+		});
+
+		source.onerror = (error) => {
+			console.error(`${event} stream error:`, error);
+		};
+
+		return () => source.close();
 	}
 
 	private commandHeaders(): HeadersInit {

--- a/src/lib/commands.svelte.ts
+++ b/src/lib/commands.svelte.ts
@@ -18,6 +18,30 @@ export interface QuerySnapshot {
 	error: string | null;
 }
 
+export type QueryEvent =
+	| {
+			type: 'submitted';
+			query_ids: QueryId[];
+	  }
+	| {
+			type: 'columns_ready';
+			query_id: QueryId;
+			columns: string[];
+	  }
+	| {
+			type: 'page_ready';
+			query_id: QueryId;
+			page_index: number;
+			page_count: number;
+	  }
+	| {
+			type: 'finished';
+			query_id: QueryId;
+			status: QueryStatus;
+			affected_rows: number | null;
+			error: string | null;
+	  };
+
 export type ConnectionConfig =
 	| { Postgres: { connection_string: string; ca_cert_path?: string | null } }
 	| { SQLite: { db_path: string } };
@@ -239,6 +263,10 @@ export class Commands {
 
 	static async getPageCount(queryId: QueryId): Promise<number> {
 		return await backend.invoke('get_page_count', { queryId });
+	}
+
+	static async listenQueryEvents(handler: (event: QueryEvent) => void): Promise<() => void> {
+		return await backend.listen<QueryEvent>('query-event', handler);
 	}
 
 	static async formatSql(query: string): Promise<string> {

--- a/src/lib/components/QueryResultsView.svelte
+++ b/src/lib/components/QueryResultsView.svelte
@@ -117,7 +117,7 @@
 		{#if executor.resultTabs.length > 0 && executor.activeResultTabId}
 			{@const activeTab = executor.resultTabs.find((t) => t.id === executor.activeResultTabId)}
 			{#if activeTab}
-				{#if activeTab.columns && activeTab.currentPageData && activeTab.currentPageData.length > 0}
+				{#if !activeTab.error && activeTab.columns && activeTab.currentPageData && activeTab.currentPageData.length > 0}
 					<div class="relative flex min-h-0 flex-1 flex-col">
 						<CardContent class="flex h-full min-h-0 flex-1 flex-col overflow-hidden p-0">
 							<Table

--- a/src/lib/queryExecutor.svelte.ts
+++ b/src/lib/queryExecutor.svelte.ts
@@ -5,7 +5,7 @@ import {
 	type QueryStatus,
 	type QueryEvent
 } from '$lib/commands.svelte';
-import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+import { SvelteMap } from 'svelte/reactivity';
 
 export interface QueryResultTab {
 	id: number;
@@ -32,8 +32,7 @@ export class QueryExecutor {
 	private onComplete?: (totalRows: number) => void;
 	private generation = 0;
 	private unlistenQueryEvents: (() => void) | null = null;
-	private activeQueryIds: SvelteSet<QueryId> | null = null;
-	private completedQueryIds = new SvelteSet<QueryId>();
+	private trackedQueries = new SvelteMap<QueryId, QueryStatus>();
 	private currentQueryText = '';
 	private queryEventListenerReady: Promise<void>;
 	private queryEventListenerError: unknown = null;
@@ -48,8 +47,7 @@ export class QueryExecutor {
 		this.stopQueryEventListener();
 		this.generation++;
 		this.latestPageRequests.clear();
-		this.activeQueryIds = null;
-		this.completedQueryIds.clear();
+		this.trackedQueries.clear();
 	}
 
 	async executeQuery(
@@ -62,8 +60,7 @@ export class QueryExecutor {
 		this.onComplete = onComplete;
 		this.currentQueryText = queryText;
 		this.latestPageRequests.clear();
-		this.activeQueryIds = null;
-		this.completedQueryIds.clear();
+		this.trackedQueries.clear();
 
 		try {
 			await this.queryEventListenerReady;
@@ -75,7 +72,7 @@ export class QueryExecutor {
 
 			if (currentGeneration !== this.generation) return;
 
-			if (!this.activeQueryIds) {
+			if (this.trackedQueries.size === 0) {
 				this.createResultTabs(queryIds, queryText);
 			}
 		} catch (error) {
@@ -85,7 +82,7 @@ export class QueryExecutor {
 			console.error('Failed to execute query:', error);
 
 			this.latestPageRequests.clear();
-			this.activeQueryIds = null;
+			this.trackedQueries.clear();
 
 			const errorMsg = error instanceof Error ? error.message : String(error);
 			const tabId = this.nextResultTabId++;
@@ -159,17 +156,17 @@ export class QueryExecutor {
 		const generation = this.generation;
 
 		if (event.type === 'submitted') {
-			if (!this.activeQueryIds) {
+			if (this.trackedQueries.size === 0) {
 				this.createResultTabs(event.query_ids, this.currentQueryText);
 			}
 			return;
 		}
 
-		if (!this.activeQueryIds) {
+		if (this.trackedQueries.size === 0) {
 			return;
 		}
 
-		if (!this.activeQueryIds.has(event.query_id)) return;
+		if (!this.trackedQueries.has(event.query_id)) return;
 
 		switch (event.type) {
 			case 'columns_ready':
@@ -211,7 +208,7 @@ export class QueryExecutor {
 
 		this.resultTabs = newTabs;
 		this.activeResultTabId = newTabs[0]?.id ?? null;
-		this.activeQueryIds = new SvelteSet(queryIds);
+		this.trackedQueries = new SvelteMap(queryIds.map((queryId) => [queryId, 'Running']));
 	}
 
 	private applyColumnsReady(event: Extract<QueryEvent, { type: 'columns_ready' }>) {
@@ -260,8 +257,8 @@ export class QueryExecutor {
 		};
 		this.resultTabs = [...this.resultTabs];
 
-		if (event.status === 'Completed' && !this.completedQueryIds.has(event.query_id)) {
-			this.completedQueryIds.add(event.query_id);
+		if (event.status === 'Completed' && this.trackedQueries.get(event.query_id) !== 'Completed') {
+			this.trackedQueries.set(event.query_id, 'Completed');
 			if (event.affected_rows != null) {
 				this.onComplete?.(event.affected_rows);
 			} else {

--- a/src/lib/queryExecutor.svelte.ts
+++ b/src/lib/queryExecutor.svelte.ts
@@ -5,7 +5,7 @@ import {
 	type QueryStatus,
 	type QueryEvent
 } from '$lib/commands.svelte';
-import { SvelteMap } from 'svelte/reactivity';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
 export interface QueryResultTab {
 	id: number;
@@ -32,8 +32,8 @@ export class QueryExecutor {
 	private onComplete?: (totalRows: number) => void;
 	private generation = 0;
 	private unlistenQueryEvents: (() => void) | null = null;
-	private activeQueryIds: Set<QueryId> | null = null;
-	private completedQueryIds = new Set<QueryId>();
+	private activeQueryIds: SvelteSet<QueryId> | null = null;
+	private completedQueryIds = new SvelteSet<QueryId>();
 	private currentQueryText = '';
 	private queryEventListenerReady: Promise<void>;
 	private queryEventListenerError: unknown = null;
@@ -211,7 +211,7 @@ export class QueryExecutor {
 
 		this.resultTabs = newTabs;
 		this.activeResultTabId = newTabs[0]?.id ?? null;
-		this.activeQueryIds = new Set(queryIds);
+		this.activeQueryIds = new SvelteSet(queryIds);
 	}
 
 	private applyColumnsReady(event: Extract<QueryEvent, { type: 'columns_ready' }>) {
@@ -226,7 +226,10 @@ export class QueryExecutor {
 		this.resultTabs = [...this.resultTabs];
 	}
 
-	private async applyPageReady(event: Extract<QueryEvent, { type: 'page_ready' }>, generation: number) {
+	private async applyPageReady(
+		event: Extract<QueryEvent, { type: 'page_ready' }>,
+		generation: number
+	) {
 		const tabIndex = this.resultTabs.findIndex((t) => t.queryId === event.query_id);
 		if (tabIndex < 0) return;
 

--- a/src/lib/queryExecutor.svelte.ts
+++ b/src/lib/queryExecutor.svelte.ts
@@ -35,10 +35,16 @@ export class QueryExecutor {
 	private activeQueryIds: Set<QueryId> | null = null;
 	private completedQueryIds = new Set<QueryId>();
 	private currentQueryText = '';
+	private queryEventListenerReady: Promise<void>;
+	private queryEventListenerError: unknown = null;
+	private disposed = false;
 
-	constructor() {}
+	constructor() {
+		this.queryEventListenerReady = this.startQueryEventListener();
+	}
 
 	dispose() {
+		this.disposed = true;
 		this.stopQueryEventListener();
 		this.generation++;
 		this.latestPageRequests.clear();
@@ -58,9 +64,13 @@ export class QueryExecutor {
 		this.latestPageRequests.clear();
 		this.activeQueryIds = null;
 		this.completedQueryIds.clear();
-		await this.ensureQueryEventListener();
 
 		try {
+			await this.queryEventListenerReady;
+			if (this.queryEventListenerError) {
+				throw this.queryEventListenerError;
+			}
+
 			const queryIds = await Commands.submitQuery(connectionId, queryText.trim());
 
 			if (currentGeneration !== this.generation) return;
@@ -120,12 +130,24 @@ export class QueryExecutor {
 		}
 	}
 
-	private async ensureQueryEventListener() {
+	private async startQueryEventListener() {
 		if (this.unlistenQueryEvents) return;
 
-		this.unlistenQueryEvents = await Commands.listenQueryEvents((event) => {
-			void this.handleQueryEvent(event);
-		});
+		try {
+			const unlisten = await Commands.listenQueryEvents((event) => {
+				void this.handleQueryEvent(event);
+			});
+
+			if (this.disposed) {
+				unlisten();
+				return;
+			}
+
+			this.unlistenQueryEvents = unlisten;
+		} catch (error) {
+			this.queryEventListenerError = error;
+			console.error('Failed to listen for query events:', error);
+		}
 	}
 
 	private stopQueryEventListener() {

--- a/src/lib/queryExecutor.svelte.ts
+++ b/src/lib/queryExecutor.svelte.ts
@@ -3,7 +3,7 @@ import {
 	type QueryId,
 	type Page,
 	type QueryStatus,
-	type QuerySnapshot
+	type QueryEvent
 } from '$lib/commands.svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
@@ -30,15 +30,20 @@ export class QueryExecutor {
 	private nextResultTabId = 1;
 	private latestPageRequests = new SvelteMap<QueryId, number>();
 	private onComplete?: (totalRows: number) => void;
-	private executionId = 0;
-	private pollingAbortController: AbortController | null = null;
+	private generation = 0;
+	private unlistenQueryEvents: (() => void) | null = null;
+	private activeQueryIds: Set<QueryId> | null = null;
+	private completedQueryIds = new Set<QueryId>();
+	private currentQueryText = '';
 
 	constructor() {}
 
 	dispose() {
-		this.stopPollingLoop();
-		this.executionId++;
+		this.stopQueryEventListener();
+		this.generation++;
 		this.latestPageRequests.clear();
+		this.activeQueryIds = null;
+		this.completedQueryIds.clear();
 	}
 
 	async executeQuery(
@@ -46,57 +51,31 @@ export class QueryExecutor {
 		connectionId: string,
 		onComplete?: (totalRows: number) => void
 	) {
-		const currentExecutionId = ++this.executionId;
+		const currentGeneration = ++this.generation;
 		// Store callback for use in completion handlers
 		this.onComplete = onComplete;
-		// Stop polling for previous queries immediately
-		this.stopPollingLoop();
+		this.currentQueryText = queryText;
+		this.latestPageRequests.clear();
+		this.activeQueryIds = null;
+		this.completedQueryIds.clear();
+		await this.ensureQueryEventListener();
 
 		try {
 			const queryIds = await Commands.submitQuery(connectionId, queryText.trim());
 
-			if (currentExecutionId !== this.executionId) return;
+			if (currentGeneration !== this.generation) return;
 
-			// Clear previous results only after we've successfully submitted the new query
-			this.latestPageRequests.clear();
-			this.resultTabs = [];
-			this.activeResultTabId = null;
-			this.nextResultTabId = 1;
-
-			// Create all tabs immediately so they show up in the UI in a "Running" state
-			const newTabs: QueryResultTab[] = queryIds.map((queryId, index) => {
-				const tabId = this.nextResultTabId++;
-				const baseTitle = this.generateTabTitle(queryText);
-				const title =
-					queryIds.length > 1 ? `${baseTitle} (${index + 1}/${queryIds.length})` : baseTitle;
-
-				return {
-					id: tabId,
-					queryId,
-					name: title,
-					query: queryText,
-					timestamp: Date.now(),
-					status: 'Running',
-					currentPageIndex: 0,
-					currentPageData: null,
-					totalPages: null
-				};
-			});
-
-			this.resultTabs = newTabs;
-			this.activeResultTabId = newTabs[0]?.id ?? null;
-
-			// Now wait for them to be renderable
-			for (const tab of newTabs) {
-				await this.waitUntilTabRenderable(tab.queryId, tab.id, currentExecutionId);
+			if (!this.activeQueryIds) {
+				this.createResultTabs(queryIds, queryText);
 			}
 		} catch (error) {
-			if (currentExecutionId !== this.executionId) {
+			if (currentGeneration !== this.generation) {
 				return;
 			}
 			console.error('Failed to execute query:', error);
 
 			this.latestPageRequests.clear();
+			this.activeQueryIds = null;
 
 			const errorMsg = error instanceof Error ? error.message : String(error);
 			const tabId = this.nextResultTabId++;
@@ -119,188 +98,6 @@ export class QueryExecutor {
 		}
 	}
 
-	private async waitUntilTabRenderable(queryId: QueryId, tabId: number, executionId: number) {
-		const info = await this.waitUntilRenderable(queryId);
-		if (executionId !== this.executionId) return;
-
-		const tabIndex = this.resultTabs.findIndex((t) => t.id === tabId);
-		if (tabIndex < 0) return;
-
-		if (info.error) {
-			this.resultTabs[tabIndex] = {
-				...this.resultTabs[tabIndex],
-				status: 'Error',
-				error: info.error
-			};
-			this.resultTabs = [...this.resultTabs];
-			return;
-		}
-
-		if (!info.returns_values) {
-			this.resultTabs[tabIndex] = {
-				...this.resultTabs[tabIndex],
-				status: info.status,
-				queryReturnsResults: false,
-				affectedRows: info.affected_rows ?? undefined
-			};
-			this.resultTabs = [...this.resultTabs];
-
-			if (info.status === 'Completed') {
-				this.onComplete?.(info.affected_rows ?? 0);
-			}
-
-			return;
-		}
-
-		if (!info.columns) {
-			this.resultTabs[tabIndex] = {
-				...this.resultTabs[tabIndex],
-				status: 'Error',
-				error: 'Failed to get column information'
-			};
-			this.resultTabs = [...this.resultTabs];
-			return;
-		}
-
-		this.resultTabs[tabIndex] = {
-			...this.resultTabs[tabIndex],
-			columns: info.columns,
-			currentPageData: info.first_page,
-			status: info.status,
-			queryReturnsResults: true
-		};
-		this.resultTabs = [...this.resultTabs];
-
-		if (info.status === 'Completed') {
-			const pageCount = await Commands.getPageCount(queryId);
-			const tabIdx = this.resultTabs.findIndex((t) => t.id === tabId);
-			if (tabIdx >= 0) {
-				this.resultTabs[tabIdx] = { ...this.resultTabs[tabIdx], totalPages: pageCount };
-				this.resultTabs = [...this.resultTabs];
-			}
-
-			this.onComplete?.((pageCount || 0) * 50);
-		} else {
-			this.startPollingLoop(executionId);
-		}
-	}
-
-	private async waitUntilRenderable(queryId: QueryId): Promise<QuerySnapshot> {
-		const now = performance.now();
-		const res = await Commands.waitUntilRenderable(queryId);
-		const elapsed = performance.now() - now;
-		console.log('Wait until renderable took', elapsed, 'ms');
-		return res;
-	}
-
-	private async pollForPage(queryId: QueryId, pageIndex: number): Promise<Page | null> {
-		for (let i = 0; i < 100; i++) {
-			const page = await Commands.fetchPage(queryId, pageIndex);
-			if (page) {
-				return page;
-			}
-			await new Promise((resolve) => setTimeout(resolve, 100));
-		}
-		console.error('Timeout waiting for page', pageIndex, 'for queryId:', queryId);
-		return null;
-	}
-
-	private startPollingLoop(executionId: number) {
-		if (this.pollingAbortController && !this.pollingAbortController.signal.aborted) {
-			return;
-		}
-
-		const controller = new AbortController();
-		this.pollingAbortController = controller;
-
-		void this.runPollingLoop(executionId, controller.signal);
-	}
-
-	private stopPollingLoop() {
-		this.pollingAbortController?.abort();
-		this.pollingAbortController = null;
-	}
-
-	private async runPollingLoop(executionId: number, signal: AbortSignal) {
-		while (!signal.aborted && executionId === this.executionId) {
-			const runningQueryIds = this.resultTabs
-				.filter((t) => t.status === 'Running' && t.queryReturnsResults !== false)
-				.map((t) => t.queryId);
-
-			if (runningQueryIds.length === 0) {
-				break;
-			}
-
-			for (const queryId of runningQueryIds) {
-				if (signal.aborted || executionId !== this.executionId) {
-					return;
-				}
-				await this.pollQueryProgress(queryId);
-			}
-
-			await this.sleep(200, signal);
-		}
-
-		if (this.pollingAbortController?.signal === signal) {
-			this.pollingAbortController = null;
-		}
-	}
-
-	private async pollQueryProgress(queryId: QueryId) {
-		try {
-			const status = await Commands.getQueryStatus(queryId);
-			const pageCount = await Commands.getPageCount(queryId);
-
-			const tabIndex = this.resultTabs.findIndex((t) => t.queryId === queryId);
-			if (tabIndex < 0) return;
-			const tab = this.resultTabs[tabIndex];
-
-			let changed = false;
-			if (tab.totalPages !== pageCount) {
-				this.resultTabs[tabIndex] = { ...this.resultTabs[tabIndex], totalPages: pageCount };
-				changed = true;
-			}
-
-			if (tab.status !== status) {
-				this.resultTabs[tabIndex] = { ...this.resultTabs[tabIndex], status };
-				changed = true;
-			}
-
-			if (changed) {
-				this.resultTabs = [...this.resultTabs];
-			}
-
-			if (status === 'Completed') {
-				const totalRows = (pageCount || 0) * 50;
-				this.onComplete?.(totalRows);
-			}
-		} catch (error) {
-			console.error('Error polling for page count:', error);
-			this.stopPollingLoop();
-		}
-	}
-
-	private async sleep(ms: number, signal?: AbortSignal): Promise<void> {
-		await new Promise<void>((resolve) => {
-			if (signal?.aborted) {
-				resolve();
-				return;
-			}
-
-			const timeout = setTimeout(() => {
-				signal?.removeEventListener('abort', onAbort);
-				resolve();
-			}, ms);
-
-			const onAbort = () => {
-				clearTimeout(timeout);
-				resolve();
-			};
-
-			signal?.addEventListener('abort', onAbort, { once: true });
-		});
-	}
-
 	async loadPage(queryId: QueryId, pageIndex: number) {
 		const tabIndex = this.resultTabs.findIndex((t) => t.queryId === queryId);
 		if (tabIndex < 0) return;
@@ -308,15 +105,143 @@ export class QueryExecutor {
 		const requestId = (this.latestPageRequests.get(queryId) ?? 0) + 1;
 		this.latestPageRequests.set(queryId, requestId);
 
-		const page = await this.pollForPage(queryId, pageIndex);
+		const page = await Commands.fetchPage(queryId, pageIndex);
 		if (this.latestPageRequests.get(queryId) !== requestId) return;
+		const latestTabIndex = this.resultTabs.findIndex((t) => t.queryId === queryId);
+		if (latestTabIndex < 0) return;
+
 		if (page) {
-			this.resultTabs[tabIndex] = {
-				...this.resultTabs[tabIndex],
+			this.resultTabs[latestTabIndex] = {
+				...this.resultTabs[latestTabIndex],
 				currentPageIndex: pageIndex,
 				currentPageData: page
 			};
 			this.resultTabs = [...this.resultTabs];
+		}
+	}
+
+	private async ensureQueryEventListener() {
+		if (this.unlistenQueryEvents) return;
+
+		this.unlistenQueryEvents = await Commands.listenQueryEvents((event) => {
+			void this.handleQueryEvent(event);
+		});
+	}
+
+	private stopQueryEventListener() {
+		this.unlistenQueryEvents?.();
+		this.unlistenQueryEvents = null;
+	}
+
+	private async handleQueryEvent(event: QueryEvent) {
+		const generation = this.generation;
+
+		if (event.type === 'submitted') {
+			if (!this.activeQueryIds) {
+				this.createResultTabs(event.query_ids, this.currentQueryText);
+			}
+			return;
+		}
+
+		if (!this.activeQueryIds) {
+			return;
+		}
+
+		if (!this.activeQueryIds.has(event.query_id)) return;
+
+		switch (event.type) {
+			case 'columns_ready':
+				this.applyColumnsReady(event);
+				break;
+			case 'page_ready':
+				await this.applyPageReady(event, generation);
+				break;
+			case 'finished':
+				this.applyFinished(event);
+				break;
+		}
+	}
+
+	private createResultTabs(queryIds: QueryId[], queryText: string) {
+		this.latestPageRequests.clear();
+		this.resultTabs = [];
+		this.activeResultTabId = null;
+		this.nextResultTabId = 1;
+
+		const newTabs: QueryResultTab[] = queryIds.map((queryId, index) => {
+			const tabId = this.nextResultTabId++;
+			const baseTitle = this.generateTabTitle(queryText);
+			const title =
+				queryIds.length > 1 ? `${baseTitle} (${index + 1}/${queryIds.length})` : baseTitle;
+
+			return {
+				id: tabId,
+				queryId,
+				name: title,
+				query: queryText,
+				timestamp: Date.now(),
+				status: 'Running',
+				currentPageIndex: 0,
+				currentPageData: null,
+				totalPages: null
+			};
+		});
+
+		this.resultTabs = newTabs;
+		this.activeResultTabId = newTabs[0]?.id ?? null;
+		this.activeQueryIds = new Set(queryIds);
+	}
+
+	private applyColumnsReady(event: Extract<QueryEvent, { type: 'columns_ready' }>) {
+		const tabIndex = this.resultTabs.findIndex((t) => t.queryId === event.query_id);
+		if (tabIndex < 0) return;
+
+		this.resultTabs[tabIndex] = {
+			...this.resultTabs[tabIndex],
+			columns: event.columns,
+			queryReturnsResults: true
+		};
+		this.resultTabs = [...this.resultTabs];
+	}
+
+	private async applyPageReady(event: Extract<QueryEvent, { type: 'page_ready' }>, generation: number) {
+		const tabIndex = this.resultTabs.findIndex((t) => t.queryId === event.query_id);
+		if (tabIndex < 0) return;
+
+		this.resultTabs[tabIndex] = {
+			...this.resultTabs[tabIndex],
+			totalPages: event.page_count
+		};
+		this.resultTabs = [...this.resultTabs];
+
+		if (event.page_index === 0 && !this.resultTabs[tabIndex].currentPageData) {
+			await this.loadPage(event.query_id, 0);
+			if (generation !== this.generation) return;
+		}
+	}
+
+	private applyFinished(event: Extract<QueryEvent, { type: 'finished' }>) {
+		const tabIndex = this.resultTabs.findIndex((t) => t.queryId === event.query_id);
+		if (tabIndex < 0) return;
+
+		const tab = this.resultTabs[tabIndex];
+
+		this.resultTabs[tabIndex] = {
+			...tab,
+			status: event.status,
+			error: event.error ?? undefined,
+			queryReturnsResults: event.affected_rows == null ? tab.queryReturnsResults : false,
+			affectedRows: event.affected_rows ?? tab.affectedRows
+		};
+		this.resultTabs = [...this.resultTabs];
+
+		if (event.status === 'Completed' && !this.completedQueryIds.has(event.query_id)) {
+			this.completedQueryIds.add(event.query_id);
+			if (event.affected_rows != null) {
+				this.onComplete?.(event.affected_rows);
+			} else {
+				this.onComplete?.((tab.totalPages || 0) * 50);
+			}
 		}
 	}
 

--- a/src/lib/queryExecutor.test.ts
+++ b/src/lib/queryExecutor.test.ts
@@ -1,16 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { QueryExecutor } from './queryExecutor.svelte';
-import type { QueryId, QueryStatus, QuerySnapshot, Page } from './commands.svelte';
+import type { Page, QueryEvent, QueryId } from './commands.svelte';
 
 vi.mock('$lib/commands.svelte', () => ({
 	Commands: {
 		submitQuery: vi.fn(),
-		waitUntilRenderable: vi.fn(),
 		fetchPage: vi.fn(),
-		getQueryStatus: vi.fn(),
-		getPageCount: vi.fn()
+		listenQueryEvents: vi.fn()
 	}
 }));
 
@@ -18,1001 +14,302 @@ import { Commands } from '$lib/commands.svelte';
 
 const mockCommands = Commands as unknown as {
 	submitQuery: ReturnType<typeof vi.fn>;
-	waitUntilRenderable: ReturnType<typeof vi.fn>;
 	fetchPage: ReturnType<typeof vi.fn>;
-	getQueryStatus: ReturnType<typeof vi.fn>;
-	getPageCount: ReturnType<typeof vi.fn>;
+	listenQueryEvents: ReturnType<typeof vi.fn>;
 };
 
-function createMockStatementInfo(overrides: Partial<QuerySnapshot> = {}): QuerySnapshot {
-	return {
-		returns_values: true,
-		status: 'Completed',
-		first_page: [[1, 'test']],
-		affected_rows: null,
-		columns: ['id'],
-		error: null,
-		...overrides
-	};
-}
+type QueryEventHandler = (event: QueryEvent) => void;
 
-function createMockPage(rows: number = 2): Page {
-	return Array.from({ length: rows }, (_, i) => [i, `row${i}`]);
+let queryEventHandler: QueryEventHandler | undefined;
+let unlistenQueryEvents: ReturnType<typeof vi.fn>;
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+
+	return { promise, resolve, reject };
 }
 
 async function flushPromises() {
-	return new Promise((resolve) => setTimeout(resolve, 0));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function emitQueryEvent(event: QueryEvent) {
+	expect(queryEventHandler).toBeDefined();
+	queryEventHandler?.(event);
+	await flushPromises();
+}
+
+function page(rows: Page): Page {
+	return rows;
 }
 
 describe('QueryExecutor', () => {
 	let executor: QueryExecutor;
 
 	beforeEach(() => {
-		executor = new QueryExecutor();
+		queryEventHandler = undefined;
+		unlistenQueryEvents = vi.fn();
 		vi.clearAllMocks();
+
+		mockCommands.listenQueryEvents.mockImplementation(async (handler: QueryEventHandler) => {
+			queryEventHandler = handler;
+			return unlistenQueryEvents;
+		});
+		mockCommands.fetchPage.mockResolvedValue(page([[1]]));
+		executor = new QueryExecutor();
 	});
 
 	afterEach(() => {
 		executor.dispose();
-		vi.clearAllTimers();
 	});
 
-	describe('Query Execution', () => {
-		it('should ignore stale async results from a previous executeQuery call', async () => {
-			const firstQueryId: QueryId = 1;
-			const secondQueryId: QueryId = 2;
-			const connectionId = 'conn-1';
+	it('starts the query event listener when constructed', () => {
+		expect(mockCommands.listenQueryEvents).toHaveBeenCalledTimes(1);
+		expect(queryEventHandler).toBeDefined();
+	});
 
-			let resolveFirstWait: ((value: QuerySnapshot) => void) | undefined;
-			const firstWait = new Promise<QuerySnapshot>((resolve) => {
-				resolveFirstWait = resolve;
-			});
+	it('waits for the query event listener before submitting a query', async () => {
+		executor.dispose();
+		vi.clearAllMocks();
+		queryEventHandler = undefined;
+		unlistenQueryEvents = vi.fn();
 
-			mockCommands.submitQuery
-				.mockResolvedValueOnce([firstQueryId])
-				.mockResolvedValueOnce([secondQueryId]);
-			mockCommands.waitUntilRenderable
-				.mockReturnValueOnce(firstWait)
-				.mockResolvedValueOnce(createMockStatementInfo({ status: 'Completed' }));
-			mockCommands.getPageCount.mockResolvedValue(1);
-
-			const firstExecution = executor.executeQuery('SELECT first', connectionId);
-			await flushPromises();
-
-			await executor.executeQuery('SELECT second', connectionId);
-			await flushPromises();
-
-			expect(executor.resultTabs).toHaveLength(1);
-			expect(executor.resultTabs[0].queryId).toBe(secondQueryId);
-			expect(executor.resultTabs[0].query).toBe('SELECT second');
-
-			resolveFirstWait!(createMockStatementInfo({ status: 'Completed' }));
-			await firstExecution;
-			await flushPromises();
-
-			expect(executor.resultTabs).toHaveLength(1);
-			expect(executor.resultTabs[0].queryId).toBe(secondQueryId);
-			expect(executor.resultTabs[0].query).toBe('SELECT second');
+		const listenerReady = createDeferred<() => void>();
+		mockCommands.listenQueryEvents.mockImplementation(async (handler: QueryEventHandler) => {
+			queryEventHandler = handler;
+			return await listenerReady.promise;
 		});
+		mockCommands.submitQuery.mockResolvedValue([1]);
 
-		it('should execute a single-statement query successfully', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'SELECT * FROM users';
-			const connectionId = 'conn-1';
+		executor = new QueryExecutor();
+		const execution = executor.executeQuery('SELECT 1', 'conn-1');
+		await flushPromises();
 
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Completed',
-					columns: ['id', 'name'],
-					first_page: [
-						[1, 'Alice'],
-						[2, 'Bob']
-					]
-				})
-			);
-			mockCommands.getPageCount.mockResolvedValue(1);
+		expect(mockCommands.submitQuery).not.toHaveBeenCalled();
 
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
+		listenerReady.resolve(unlistenQueryEvents);
+		await execution;
 
-			expect(executor.resultTabs).toHaveLength(1);
-			expect(executor.resultTabs[0]).toMatchObject({
-				queryId,
-				query: queryText,
-				status: 'Completed',
-				queryReturnsResults: true,
-				columns: ['id', 'name'],
-				currentPageIndex: 0,
-				totalPages: 1
-			});
-			expect(executor.activeResultTabId).toBe(executor.resultTabs[0].id);
+		expect(mockCommands.submitQuery).toHaveBeenCalledWith('conn-1', 'SELECT 1');
+	});
+
+	it('creates result tabs from the submitted event before submitQuery returns', async () => {
+		const submit = createDeferred<QueryId[]>();
+		mockCommands.submitQuery.mockReturnValue(submit.promise);
+
+		const execution = executor.executeQuery('SELECT 1; SELECT 2', 'conn-1');
+		await flushPromises();
+
+		await emitQueryEvent({ type: 'submitted', query_ids: [10, 11] });
+
+		expect(executor.resultTabs).toHaveLength(2);
+		expect(executor.resultTabs.map((tab) => tab.queryId)).toEqual([10, 11]);
+		expect(executor.resultTabs.map((tab) => tab.status)).toEqual(['Running', 'Running']);
+
+		submit.resolve([10, 11]);
+		await execution;
+		await flushPromises();
+
+		expect(executor.resultTabs).toHaveLength(2);
+		expect(executor.resultTabs.map((tab) => tab.queryId)).toEqual([10, 11]);
+	});
+
+	it('falls back to the submitQuery response when the submitted event arrives later', async () => {
+		mockCommands.submitQuery.mockResolvedValue([42]);
+
+		await executor.executeQuery('SELECT 1', 'conn-1');
+
+		expect(executor.resultTabs).toHaveLength(1);
+		expect(executor.resultTabs[0]).toMatchObject({
+			queryId: 42,
+			query: 'SELECT 1',
+			status: 'Running'
 		});
+		expect(executor.activeResultTabId).toBe(executor.resultTabs[0].id);
+	});
 
-		it('should execute a multi-statement query and create multiple tabs', async () => {
-			const queryIds: QueryId[] = [1, 2];
-			const queryText = 'SELECT * FROM users; SELECT * FROM posts';
-			const connectionId = 'conn-1';
+	it('ignores duplicate submitted events after tabs already exist', async () => {
+		mockCommands.submitQuery.mockResolvedValue([1]);
 
-			mockCommands.submitQuery.mockResolvedValue(queryIds);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({ status: 'Completed' })
-			);
-			mockCommands.getPageCount.mockResolvedValue(1);
+		await executor.executeQuery('SELECT 1', 'conn-1');
+		const originalTabId = executor.resultTabs[0].id;
 
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
+		await emitQueryEvent({ type: 'submitted', query_ids: [1] });
 
-			expect(executor.resultTabs).toHaveLength(2);
-			expect(executor.resultTabs[0].queryId).toBe(1);
-			expect(executor.resultTabs[1].queryId).toBe(2);
-			expect(executor.activeResultTabId).toBe(executor.resultTabs[0].id);
-		});
+		expect(executor.resultTabs).toHaveLength(1);
+		expect(executor.resultTabs[0].id).toBe(originalTabId);
+	});
 
-		it('should handle query execution errors gracefully', async () => {
-			const queryText = 'SELECT * FROM invalid_table';
-			const connectionId = 'conn-1';
-			const errorMessage = 'Table does not exist';
+	it('applies columns and loads the first page when a page becomes ready', async () => {
+		mockCommands.submitQuery.mockResolvedValue([1]);
+		mockCommands.fetchPage.mockResolvedValue(
+			page([
+				[1, 'Alice'],
+				[2, 'Bob']
+			])
+		);
 
-			mockCommands.submitQuery.mockRejectedValue(new Error(errorMessage));
+		await executor.executeQuery('SELECT * FROM users', 'conn-1');
+		await emitQueryEvent({ type: 'columns_ready', query_id: 1, columns: ['id', 'name'] });
+		await emitQueryEvent({ type: 'page_ready', query_id: 1, page_index: 0, page_count: 3 });
 
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			expect(executor.resultTabs).toHaveLength(1);
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Error',
-				error: errorMessage,
-				queryId: -1
-			});
-		});
-
-		it('should handle query with results vs query without results', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'INSERT INTO users VALUES (1, "test")';
-			const connectionId = 'conn-1';
-			const affectedRows = 1;
-
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					returns_values: false,
-					status: 'Completed',
-					first_page: null,
-					affected_rows: affectedRows
-				})
-			);
-
-			const onComplete = vi.fn();
-			await executor.executeQuery(queryText, connectionId, onComplete);
-			await flushPromises();
-
-			expect(executor.resultTabs).toHaveLength(1);
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Completed',
-				queryReturnsResults: false,
-				affectedRows
-			});
-			expect(onComplete).toHaveBeenCalledWith(affectedRows);
-		});
-
-		it('should handle statement-level errors', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'SELECT * FROM users';
-			const connectionId = 'conn-1';
-			const errorMessage = 'Column does not exist';
-
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Error',
-					error: errorMessage
-				})
-			);
-
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			expect(executor.resultTabs).toHaveLength(1);
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Error',
-				error: errorMessage
-			});
-		});
-
-		it('should call onComplete with correct row count', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'SELECT * FROM users';
-			const connectionId = 'conn-1';
-			const pageCount = 5;
-			const onComplete = vi.fn();
-
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({ status: 'Completed' })
-			);
-			mockCommands.getPageCount.mockResolvedValue(pageCount);
-
-			await executor.executeQuery(queryText, connectionId, onComplete);
-			await flushPromises();
-
-			// 50 rows per page * 5 pages = 250 rows
-			expect(onComplete).toHaveBeenCalledWith(250);
-		});
-
-		it('should not call onComplete on errors', async () => {
-			const queryText = 'SELECT * FROM invalid';
-			const connectionId = 'conn-1';
-			const onComplete = vi.fn();
-
-			mockCommands.submitQuery.mockRejectedValue(new Error('SQL error'));
-
-			await executor.executeQuery(queryText, connectionId, onComplete);
-			await flushPromises();
-
-			expect(onComplete).not.toHaveBeenCalled();
+		expect(mockCommands.fetchPage).toHaveBeenCalledWith(1, 0);
+		expect(executor.resultTabs[0]).toMatchObject({
+			columns: ['id', 'name'],
+			queryReturnsResults: true,
+			currentPageIndex: 0,
+			currentPageData: [
+				[1, 'Alice'],
+				[2, 'Bob']
+			],
+			totalPages: 3
 		});
 	});
 
-	describe('Tab Management', () => {
-		it('should set active tab correctly on initial load', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'SELECT * FROM users';
-			const connectionId = 'conn-1';
+	it('marks row-returning queries complete and reports the current page-count estimate', async () => {
+		const onComplete = vi.fn();
+		mockCommands.submitQuery.mockResolvedValue([1]);
 
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({ status: 'Completed' })
-			);
-			mockCommands.getPageCount.mockResolvedValue(1);
-
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			expect(executor.activeResultTabId).toBe(executor.resultTabs[0].id);
+		await executor.executeQuery('SELECT * FROM users', 'conn-1', onComplete);
+		await emitQueryEvent({ type: 'columns_ready', query_id: 1, columns: ['id'] });
+		await emitQueryEvent({ type: 'page_ready', query_id: 1, page_index: 0, page_count: 2 });
+		await emitQueryEvent({
+			type: 'finished',
+			query_id: 1,
+			status: 'Completed',
+			affected_rows: null,
+			error: null
 		});
 
-		it('should switch between tabs', async () => {
-			const queryIds: QueryId[] = [1, 2];
-			const queryText = 'SELECT 1; SELECT 2';
-			const connectionId = 'conn-1';
+		expect(executor.resultTabs[0]).toMatchObject({
+			status: 'Completed',
+			queryReturnsResults: true,
+			totalPages: 2
+		});
+		expect(onComplete).toHaveBeenCalledTimes(1);
+		expect(onComplete).toHaveBeenCalledWith(100);
+	});
 
-			mockCommands.submitQuery.mockResolvedValue(queryIds);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({ status: 'Completed' })
-			);
-			mockCommands.getPageCount.mockResolvedValue(1);
+	it('marks mutation queries complete with affected rows', async () => {
+		const onComplete = vi.fn();
+		mockCommands.submitQuery.mockResolvedValue([5]);
 
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			const firstTabId = executor.resultTabs[0].id;
-			const secondTabId = executor.resultTabs[1].id;
-
-			executor.handleResultTabSelect(firstTabId);
-			expect(executor.activeResultTabId).toBe(firstTabId);
-
-			executor.handleResultTabSelect(secondTabId);
-			expect(executor.activeResultTabId).toBe(secondTabId);
+		await executor.executeQuery('UPDATE users SET active = true', 'conn-1', onComplete);
+		await emitQueryEvent({
+			type: 'finished',
+			query_id: 5,
+			status: 'Completed',
+			affected_rows: 7,
+			error: null
 		});
 
-		it('should close tab and update active tab appropriately', async () => {
-			const queryIds: QueryId[] = [1, 2, 3];
-			const queryText = 'SELECT 1; SELECT 2; SELECT 3';
-			const connectionId = 'conn-1';
+		expect(executor.resultTabs[0]).toMatchObject({
+			status: 'Completed',
+			queryReturnsResults: false,
+			affectedRows: 7
+		});
+		expect(onComplete).toHaveBeenCalledWith(7);
+	});
 
-			mockCommands.submitQuery.mockResolvedValue(queryIds);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({ status: 'Completed' })
-			);
-			mockCommands.getPageCount.mockResolvedValue(1);
+	it('marks statement errors without calling onComplete', async () => {
+		const onComplete = vi.fn();
+		mockCommands.submitQuery.mockResolvedValue([1]);
 
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			expect(executor.resultTabs).toHaveLength(3);
-			const middleTabId = executor.resultTabs[1].id;
-
-			executor.handleResultTabClose(middleTabId);
-
-			expect(executor.resultTabs).toHaveLength(2);
-			expect(executor.resultTabs.find((t) => t.id === middleTabId)).toBeUndefined();
+		await executor.executeQuery('SELECT * FROM missing_table', 'conn-1', onComplete);
+		await emitQueryEvent({
+			type: 'finished',
+			query_id: 1,
+			status: 'Error',
+			affected_rows: null,
+			error: 'no such table: missing_table'
 		});
 
-		it('should close active tab and switch to another tab', async () => {
-			const queryIds: QueryId[] = [1, 2];
-			const queryText = 'SELECT 1; SELECT 2';
-			const connectionId = 'conn-1';
+		expect(executor.resultTabs[0]).toMatchObject({
+			status: 'Error',
+			error: 'no such table: missing_table'
+		});
+		expect(onComplete).not.toHaveBeenCalled();
+	});
 
-			mockCommands.submitQuery.mockResolvedValue(queryIds);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({ status: 'Completed' })
-			);
-			mockCommands.getPageCount.mockResolvedValue(1);
+	it('ignores events for stale query ids after a new query starts', async () => {
+		mockCommands.submitQuery.mockResolvedValueOnce([1]).mockResolvedValueOnce([2]);
 
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			const firstTabId = executor.resultTabs[0].id;
-			const secondTabId = executor.resultTabs[1].id;
-
-			// active tab is the first result by default
-			expect(executor.activeResultTabId).toBe(firstTabId);
-
-			executor.handleResultTabClose(firstTabId);
-
-			expect(executor.resultTabs).toHaveLength(1);
-			expect(executor.activeResultTabId).toBe(secondTabId);
+		await executor.executeQuery('SELECT old', 'conn-1');
+		await executor.executeQuery('SELECT new', 'conn-1');
+		await emitQueryEvent({
+			type: 'finished',
+			query_id: 1,
+			status: 'Error',
+			affected_rows: null,
+			error: 'old query failed late'
 		});
 
-		it('should set activeResultTabId to null when closing last tab', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'SELECT 1';
-			const connectionId = 'conn-1';
+		expect(executor.resultTabs).toHaveLength(1);
+		expect(executor.resultTabs[0]).toMatchObject({
+			queryId: 2,
+			query: 'SELECT new',
+			status: 'Running'
+		});
+		expect(executor.resultTabs[0].error).toBeUndefined();
+	});
 
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({ status: 'Completed' })
-			);
-			mockCommands.getPageCount.mockResolvedValue(1);
+	it('keeps a single event listener for repeated executions and unregisters it on dispose', async () => {
+		mockCommands.submitQuery.mockResolvedValueOnce([1]).mockResolvedValueOnce([2]);
 
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
+		await executor.executeQuery('SELECT 1', 'conn-1');
+		await executor.executeQuery('SELECT 2', 'conn-1');
 
-			const tabId = executor.resultTabs[0].id;
-			executor.handleResultTabClose(tabId);
+		expect(mockCommands.listenQueryEvents).toHaveBeenCalledTimes(1);
+		expect(unlistenQueryEvents).not.toHaveBeenCalled();
 
-			expect(executor.resultTabs).toHaveLength(0);
-			expect(executor.activeResultTabId).toBeNull();
+		executor.dispose();
+
+		expect(unlistenQueryEvents).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps the latest requested page when concurrent page loads race', async () => {
+		const firstPage = createDeferred<Page | null>();
+		const secondPage = createDeferred<Page | null>();
+		mockCommands.submitQuery.mockResolvedValue([1]);
+		mockCommands.fetchPage
+			.mockReturnValueOnce(firstPage.promise)
+			.mockReturnValueOnce(secondPage.promise);
+
+		await executor.executeQuery('SELECT * FROM users', 'conn-1');
+		const firstLoad = executor.loadPage(1, 1);
+		const secondLoad = executor.loadPage(1, 2);
+
+		secondPage.resolve(page([[2, 'second']]));
+		await secondLoad;
+		firstPage.resolve(page([[1, 'first']]));
+		await firstLoad;
+
+		expect(executor.resultTabs[0]).toMatchObject({
+			currentPageIndex: 2,
+			currentPageData: [[2, 'second']]
 		});
 	});
 
-	describe('Result States', () => {
-		it('should handle query with results status=Completed', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'SELECT * FROM users';
-			const connectionId = 'conn-1';
+	it('supports result tab selection and closing', async () => {
+		mockCommands.submitQuery.mockResolvedValue([1, 2]);
 
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Completed',
-					returns_values: true,
-					first_page: [[1, 'test']]
-				})
-			);
-			mockCommands.getPageCount.mockResolvedValue(1);
+		await executor.executeQuery('SELECT 1; SELECT 2', 'conn-1');
+		const [firstTab, secondTab] = executor.resultTabs;
 
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
+		executor.handleResultTabSelect(secondTab.id);
+		expect(executor.activeResultTabId).toBe(secondTab.id);
 
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Completed',
-				queryReturnsResults: true
-			});
-		});
+		executor.handleResultTabClose(secondTab.id);
+		expect(executor.resultTabs).toHaveLength(1);
+		expect(executor.activeResultTabId).toBe(firstTab.id);
 
-		it('should handle query without results showing affected_rows', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'UPDATE users SET name = "test"';
-			const connectionId = 'conn-1';
-
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					returns_values: false,
-					status: 'Completed',
-					first_page: null,
-					affected_rows: 42
-				})
-			);
-
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Completed',
-				queryReturnsResults: false,
-				affectedRows: 42
-			});
-		});
-
-		it('should show running status initially', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'SELECT * FROM users';
-			const connectionId = 'conn-1';
-
-			// Delay waitUntilRenderable to simulate running state
-			let resolveWait: (value: QuerySnapshot) => void;
-			const waitPromise = new Promise<QuerySnapshot>((resolve) => {
-				resolveWait = resolve;
-			});
-
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockReturnValue(waitPromise);
-
-			const executePromise = executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Running'
-			});
-
-			// Complete the query
-			resolveWait!(createMockStatementInfo({ status: 'Completed' }));
-			mockCommands.getPageCount.mockResolvedValue(1);
-			await executePromise;
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Completed'
-			});
-		});
-
-		it('should handle failed query with error message', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'SELECT * FROM invalid';
-			const connectionId = 'conn-1';
-			const errorMessage = 'Syntax error';
-
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Error',
-					error: errorMessage
-				})
-			);
-
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Error',
-				error: errorMessage
-			});
-		});
-
-		it('should handle empty result set (0 rows)', async () => {
-			const queryId: QueryId = 1;
-			const queryText = 'SELECT * FROM users WHERE id = -1';
-			const connectionId = 'conn-1';
-
-			mockCommands.submitQuery.mockResolvedValue([queryId]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Completed',
-					returns_values: true,
-					first_page: []
-				})
-			);
-			mockCommands.getPageCount.mockResolvedValue(0);
-
-			await executor.executeQuery(queryText, connectionId);
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Completed',
-				queryReturnsResults: true,
-				totalPages: 0,
-				currentPageData: []
-			});
-		});
-	});
-
-	describe('Pagination', () => {
-		beforeEach(() => {
-			// Set up a common scenario with paginated results
-			mockCommands.submitQuery.mockResolvedValue([1]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Completed',
-					first_page: createMockPage(2)
-				})
-			);
-		});
-
-		it('should load initial page (page 0)', async () => {
-			mockCommands.getPageCount.mockResolvedValue(3);
-
-			await executor.executeQuery('SELECT * FROM users', 'conn-1');
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				currentPageIndex: 0,
-				currentPageData: createMockPage(2)
-			});
-		});
-
-		it('should load next page', async () => {
-			mockCommands.getPageCount.mockResolvedValue(3);
-			const page1Data = createMockPage(3);
-			mockCommands.fetchPage.mockResolvedValue(page1Data);
-
-			await executor.executeQuery('SELECT * FROM users', 'conn-1');
-			await flushPromises();
-
-			const queryId = executor.resultTabs[0].queryId;
-			await executor.loadPage(queryId, 1);
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				currentPageIndex: 1,
-				currentPageData: page1Data
-			});
-			expect(mockCommands.fetchPage).toHaveBeenCalledWith(queryId, 1);
-		});
-
-		it('should load previous page', async () => {
-			mockCommands.getPageCount.mockResolvedValue(3);
-			const page0Data = createMockPage(2);
-			mockCommands.fetchPage.mockResolvedValue(page0Data);
-
-			await executor.executeQuery('SELECT * FROM users', 'conn-1');
-			await flushPromises();
-
-			const queryId = executor.resultTabs[0].queryId;
-
-			// Load page 1 first
-			await executor.loadPage(queryId, 1);
-			await flushPromises();
-
-			// Then go back to page 0
-			await executor.loadPage(queryId, 0);
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				currentPageIndex: 0
-			});
-		});
-
-		it('should load specific page number', async () => {
-			mockCommands.getPageCount.mockResolvedValue(10);
-			const page5Data = createMockPage(4);
-			mockCommands.fetchPage.mockResolvedValue(page5Data);
-
-			await executor.executeQuery('SELECT * FROM users', 'conn-1');
-			await flushPromises();
-
-			const queryId = executor.resultTabs[0].queryId;
-			await executor.loadPage(queryId, 5);
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				currentPageIndex: 5,
-				currentPageData: page5Data
-			});
-			expect(mockCommands.fetchPage).toHaveBeenCalledWith(queryId, 5);
-		});
-
-		it('should handle page loading for non-existent tab gracefully', async () => {
-			mockCommands.getPageCount.mockResolvedValue(2);
-
-			await executor.executeQuery('SELECT * FROM users', 'conn-1');
-			await flushPromises();
-
-			// Try to load page for a non-existent query ID
-			await executor.loadPage(9999, 1);
-			await flushPromises();
-
-			// Should not throw, tab should remain unchanged
-			expect(executor.resultTabs[0].currentPageIndex).toBe(0);
-		});
-
-		it('should keep latest page request when concurrent loadPage calls race', async () => {
-			vi.useFakeTimers();
-
-			try {
-				mockCommands.getPageCount.mockResolvedValue(3);
-
-				const slowPage = createMockPage(1);
-				const fastPage = createMockPage(4);
-				let slowAttempts = 0;
-				mockCommands.fetchPage.mockImplementation(async (_queryId, pageIndex) => {
-					if (pageIndex === 1) {
-						slowAttempts++;
-						return slowAttempts >= 3 ? slowPage : null;
-					}
-					if (pageIndex === 2) {
-						return fastPage;
-					}
-					return null;
-				});
-
-				await executor.executeQuery('SELECT * FROM users', 'conn-1');
-				await Promise.resolve();
-
-				const queryId = executor.resultTabs[0].queryId;
-				const slowLoad = executor.loadPage(queryId, 1);
-				const fastLoad = executor.loadPage(queryId, 2);
-
-				await fastLoad;
-				expect(executor.resultTabs[0].currentPageIndex).toBe(2);
-				expect(executor.resultTabs[0].currentPageData).toEqual(fastPage);
-
-				await vi.advanceTimersByTimeAsync(350);
-				await slowLoad;
-
-				expect(executor.resultTabs[0].currentPageIndex).toBe(2);
-				expect(executor.resultTabs[0].currentPageData).toEqual(fastPage);
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should keep current page unchanged when loadPage times out', async () => {
-			vi.useFakeTimers();
-
-			try {
-				mockCommands.getPageCount.mockResolvedValue(2);
-				mockCommands.fetchPage.mockResolvedValue(null);
-
-				await executor.executeQuery('SELECT * FROM users', 'conn-1');
-				await Promise.resolve();
-
-				const initialPage = executor.resultTabs[0].currentPageData;
-				const queryId = executor.resultTabs[0].queryId;
-				const loadPromise = executor.loadPage(queryId, 1);
-
-				await vi.advanceTimersByTimeAsync(10100);
-				await loadPromise;
-
-				expect(executor.resultTabs[0].currentPageIndex).toBe(0);
-				expect(executor.resultTabs[0].currentPageData).toEqual(initialPage);
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-	});
-
-	describe('Polling & Cleanup', () => {
-		it('should run polling loop and stop after completion', async () => {
-			vi.useFakeTimers();
-
-			try {
-				const queryId: QueryId = 1;
-				let statusCalls = 0;
-
-				mockCommands.submitQuery.mockResolvedValue([queryId]);
-				mockCommands.waitUntilRenderable.mockResolvedValue(
-					createMockStatementInfo({
-						status: 'Running',
-						returns_values: true,
-						first_page: [[1]]
-					})
-				);
-				mockCommands.getQueryStatus.mockImplementation(() => {
-					statusCalls++;
-					return Promise.resolve((statusCalls < 2 ? 'Running' : 'Completed') as QueryStatus);
-				});
-				mockCommands.getPageCount.mockResolvedValue(2);
-
-				await executor.executeQuery('SELECT * FROM users', 'conn-1');
-				await Promise.resolve();
-
-				await vi.advanceTimersByTimeAsync(250);
-				await Promise.resolve();
-
-				const statusCallsAfterComplete = mockCommands.getQueryStatus.mock.calls.length;
-				await vi.advanceTimersByTimeAsync(1000);
-				await Promise.resolve();
-				expect(mockCommands.getQueryStatus.mock.calls.length).toBe(statusCallsAfterComplete);
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should poll for page count while query is running', async () => {
-			vi.useFakeTimers();
-
-			try {
-				const queryId: QueryId = 1;
-				let getStatusCallCount = 0;
-
-				mockCommands.submitQuery.mockResolvedValue([queryId]);
-				mockCommands.waitUntilRenderable.mockResolvedValue(
-					createMockStatementInfo({
-						status: 'Running',
-						returns_values: true,
-						first_page: [[1]]
-					})
-				);
-
-				// Make status transition happen after a couple polls
-				mockCommands.getQueryStatus.mockImplementation(() => {
-					getStatusCallCount++;
-					if (getStatusCallCount <= 2) {
-						return Promise.resolve('Running' as QueryStatus);
-					}
-					return Promise.resolve('Completed' as QueryStatus);
-				});
-
-				mockCommands.getPageCount.mockImplementation(() => {
-					if (getStatusCallCount <= 2) {
-						return Promise.resolve(null as any);
-					}
-					return Promise.resolve(5);
-				});
-
-				const executePromise = executor.executeQuery('SELECT * FROM users', 'conn-1');
-				await vi.runOnlyPendingTimersAsync();
-
-				// Initial poll should have occurred, verify polling is set up
-				expect(getStatusCallCount).toBeGreaterThanOrEqual(1);
-
-				// Advance through multiple poll cycles
-				await vi.advanceTimersByTimeAsync(400);
-
-				// Should have polled multiple times and eventually completed
-				expect(getStatusCallCount).toBeGreaterThanOrEqual(3);
-				expect(executor.resultTabs[0]).toMatchObject({
-					status: 'Completed',
-					totalPages: 5
-				});
-
-				await executePromise;
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should stop polling when query is completed', async () => {
-			vi.useFakeTimers();
-
-			try {
-				const queryId: QueryId = 1;
-				mockCommands.submitQuery.mockResolvedValue([queryId]);
-				mockCommands.waitUntilRenderable.mockResolvedValue(
-					createMockStatementInfo({
-						status: 'Running',
-						returns_values: true,
-						first_page: [[1]]
-					})
-				);
-				mockCommands.getQueryStatus.mockResolvedValue('Completed' as QueryStatus);
-				mockCommands.getPageCount.mockResolvedValue(3);
-
-				const executePromise = executor.executeQuery('SELECT * FROM users', 'conn-1');
-				await vi.runOnlyPendingTimersAsync();
-
-				// Advance timers to trigger one poll
-				await vi.advanceTimersByTimeAsync(200);
-
-				const pollCallCount = mockCommands.getQueryStatus.mock.calls.length;
-
-				// Advance much further - polling should have stopped
-				await vi.advanceTimersByTimeAsync(2000);
-
-				// Should not have called getQueryStatus more times
-				expect(mockCommands.getQueryStatus.mock.calls.length).toBe(pollCallCount);
-
-				await executePromise;
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should stop polling when getQueryStatus/getPageCount throws', async () => {
-			vi.useFakeTimers();
-
-			try {
-				const queryId: QueryId = 1;
-				mockCommands.submitQuery.mockResolvedValue([queryId]);
-				mockCommands.waitUntilRenderable.mockResolvedValue(
-					createMockStatementInfo({
-						status: 'Running',
-						returns_values: true,
-						first_page: [[1]]
-					})
-				);
-				mockCommands.getQueryStatus.mockRejectedValue(new Error('poll failed'));
-				mockCommands.getPageCount.mockResolvedValue(0);
-
-				await executor.executeQuery('SELECT * FROM users', 'conn-1');
-				await Promise.resolve();
-
-				await vi.advanceTimersByTimeAsync(250);
-				await Promise.resolve();
-
-				const statusCallsAfterFailure = mockCommands.getQueryStatus.mock.calls.length;
-
-				await vi.advanceTimersByTimeAsync(1000);
-				await Promise.resolve();
-
-				expect(mockCommands.getQueryStatus.mock.calls.length).toBe(statusCallsAfterFailure);
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should stop polling loop on dispose', async () => {
-			vi.useFakeTimers();
-
-			try {
-				const queryIds: QueryId[] = [1, 2];
-				mockCommands.submitQuery.mockResolvedValue(queryIds);
-				mockCommands.waitUntilRenderable.mockResolvedValue(
-					createMockStatementInfo({
-						status: 'Running',
-						returns_values: true,
-						first_page: [[1]]
-					})
-				);
-				mockCommands.getQueryStatus.mockResolvedValue('Running' as QueryStatus);
-				mockCommands.getPageCount.mockResolvedValue(null as any);
-
-				const executePromise = executor.executeQuery('SELECT 1; SELECT 2', 'conn-1');
-				await vi.runOnlyPendingTimersAsync();
-
-				// Should have started polling for both queries
-				const statusCallsBefore = mockCommands.getQueryStatus.mock.calls.length;
-
-				executor.dispose();
-
-				// Advance timers - polling should not continue
-				await vi.advanceTimersByTimeAsync(1000);
-
-				// No new calls should have been made
-				expect(mockCommands.getQueryStatus.mock.calls.length).toBe(statusCallsBefore);
-
-				await executePromise.catch(() => {}); // May have been interrupted
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should be safe to call dispose multiple times', () => {
-			executor.dispose();
-			executor.dispose();
-			executor.dispose();
-
-			// Should not throw
-			expect(true).toBe(true);
-		});
-
-		it('should stop old polling loop when executing a new query', async () => {
-			vi.useFakeTimers();
-
-			try {
-				// Execute first query with polling
-				mockCommands.submitQuery.mockResolvedValue([1]);
-				mockCommands.waitUntilRenderable.mockResolvedValue(
-					createMockStatementInfo({
-						status: 'Running',
-						returns_values: true,
-						first_page: [[1]]
-					})
-				);
-				mockCommands.getQueryStatus.mockResolvedValue('Running' as QueryStatus);
-				mockCommands.getPageCount.mockResolvedValue(null as any);
-
-				const execute1Promise = executor.executeQuery('SELECT 1', 'conn-1');
-				await vi.runOnlyPendingTimersAsync();
-
-				// Execute second query (should clear first query's intervals)
-				mockCommands.submitQuery.mockResolvedValue([2]);
-				const execute2Promise = executor.executeQuery('SELECT 2', 'conn-1');
-				await vi.runOnlyPendingTimersAsync();
-
-				// Advance timers
-				await vi.advanceTimersByTimeAsync(200);
-
-				// Should only be polling for the second query (queryId 2)
-				// The mock doesn't distinguish between queries, but we verify no errors occur
-				expect(executor.resultTabs).toHaveLength(1);
-				expect(executor.resultTabs[0].queryId).toBe(2);
-
-				await execute1Promise.catch(() => {}); // May have been cleared
-				await execute2Promise.catch(() => {}); // May still be running
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-	});
-
-	describe('Edge Cases', () => {
-		it('should generate tab title correctly for short queries', async () => {
-			const shortQuery = 'SELECT 1';
-			mockCommands.submitQuery.mockResolvedValue([1]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Completed',
-					returns_values: false,
-					affected_rows: 1
-				})
-			);
-
-			await executor.executeQuery(shortQuery, 'conn-1');
-			await flushPromises();
-
-			expect(executor.resultTabs[0].name).toBe(shortQuery);
-		});
-
-		it('should truncate long query titles', async () => {
-			const longQuery = 'SELECT * FROM users WHERE name LIKE "%test%" AND age > 18';
-			mockCommands.submitQuery.mockResolvedValue([1]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Completed',
-					returns_values: false,
-					affected_rows: 0
-				})
-			);
-
-			await executor.executeQuery(longQuery, 'conn-1');
-			await flushPromises();
-
-			expect(executor.resultTabs[0].name.length).toBeLessThanOrEqual(30);
-			expect(executor.resultTabs[0].name.endsWith('...')).toBe(true);
-		});
-
-		it('should handle query with many columns', async () => {
-			const manyColumns = Array.from({ length: 100 }, (_, i) => `col${i}`);
-			mockCommands.submitQuery.mockResolvedValue([1]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Completed',
-					returns_values: true,
-					first_page: [[]],
-					columns: manyColumns
-				})
-			);
-			mockCommands.getPageCount.mockResolvedValue(1);
-
-			await executor.executeQuery('SELECT * FROM wide_table', 'conn-1');
-			await flushPromises();
-
-			expect(executor.resultTabs[0].columns).toHaveLength(100);
-		});
-
-		it('should handle failure to get column information', async () => {
-			mockCommands.submitQuery.mockResolvedValue([1]);
-			mockCommands.waitUntilRenderable.mockResolvedValue(
-				createMockStatementInfo({
-					status: 'Completed',
-					returns_values: true,
-					first_page: [[1]],
-					columns: null
-				})
-			);
-
-			await executor.executeQuery('SELECT * FROM users', 'conn-1');
-			await flushPromises();
-
-			expect(executor.resultTabs[0]).toMatchObject({
-				status: 'Error',
-				error: 'Failed to get column information'
-			});
-		});
-
-		it('should return correct tab status for getTabStatus', async () => {
-			mockCommands.submitQuery.mockResolvedValue([1, 2, 3]);
-			mockCommands.waitUntilRenderable
-				.mockResolvedValueOnce(
-					createMockStatementInfo({
-						status: 'Completed',
-						returns_values: false,
-						affected_rows: 1
-					})
-				)
-				.mockResolvedValueOnce(
-					createMockStatementInfo({
-						status: 'Running',
-						returns_values: false
-					})
-				)
-				.mockResolvedValueOnce(
-					createMockStatementInfo({
-						status: 'Error',
-						error: 'Test error'
-					})
-				);
-
-			await executor.executeQuery('SELECT 1; SELECT 2; SELECT 3', 'conn-1');
-			await flushPromises();
-
-			expect(executor.getTabStatus(executor.resultTabs[0])).toBe('normal');
-			expect(executor.getTabStatus(executor.resultTabs[1])).toBe('modified');
-			expect(executor.getTabStatus(executor.resultTabs[2])).toBe('error');
-		});
+		executor.handleResultTabClose(firstTab.id);
+		expect(executor.resultTabs).toHaveLength(0);
+		expect(executor.activeResultTabId).toBeNull();
 	});
 });


### PR DESCRIPTION
- refactor query execution state in `pgpad-core` into a simpler, ideally more reliable model
- query IDs are now handled by the backend, being monotonic IDs
- frontend no longer polls backend for query updates, it gets it from a small channel (Tauri channels, or SSE for pgpad-web)
- Replaced QueryExecutor tests for the new logic
- pgpad-core tests for query event ordering, result pages, mutations, errors, etc